### PR TITLE
Create Seller and Buyer classes with add commands and test cases

### DIFF
--- a/src/main/java/seedu/address/logic/commands/AddBuyerCommand.java
+++ b/src/main/java/seedu/address/logic/commands/AddBuyerCommand.java
@@ -1,0 +1,94 @@
+package seedu.address.logic.commands;
+
+import static java.util.Objects.requireNonNull;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_ADDRESS;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_EMAIL;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_NAME;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_PHONE;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_POSTALCODE;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_TAG;
+
+import seedu.address.commons.util.ToStringBuilder;
+import seedu.address.logic.Messages;
+import seedu.address.logic.commands.exceptions.CommandException;
+import seedu.address.model.Model;
+import seedu.address.model.person.Person;
+
+/**
+ * Adds a buyer to the address book.
+ */
+public class AddBuyerCommand extends Command {
+
+    public static final String COMMAND_WORD = "addbuyer";
+
+    public static final String MESSAGE_USAGE = COMMAND_WORD + ": Adds a buyer to the address book. "
+            + "Parameters: "
+            + PREFIX_NAME + "NAME "
+            + PREFIX_PHONE + "PHONE "
+            + PREFIX_EMAIL + "EMAIL "
+            + PREFIX_ADDRESS + "ADDRESS "
+            + PREFIX_POSTALCODE + "POSTAL CODE "
+            + "[" + PREFIX_TAG + "TAG]...\n"
+            + "Example: " + COMMAND_WORD + " "
+            + PREFIX_NAME + "John Doe "
+            + PREFIX_PHONE + "98765432 "
+            + PREFIX_EMAIL + "johnd@example.com "
+            + PREFIX_ADDRESS + "311, Clementi Ave 2, #02-25 "
+            + PREFIX_POSTALCODE + "578578 "
+            + PREFIX_TAG + "friends "
+            + PREFIX_TAG + "owesMoney";
+
+    public static final String MESSAGE_SUCCESS = "New buyer added: %1$s";
+    public static final String MESSAGE_DUPLICATE_PERSON = "This buyer already exists in the address book";
+
+    private final Person buyerToAdd;
+
+    /**
+     * Creates an AddBuyerCommand to add the specified buyer.
+     * @param person The buyer to be added.
+     */
+    public AddBuyerCommand(Person person) {
+        requireNonNull(person);
+        buyerToAdd = person;
+    }
+    /**
+     * Executes the command and returns the result message.
+     *
+     * @param model {@code Model} which the command should operate on.
+     * @return feedback message of the operation result for display
+     * @throws CommandException If an error occurs during command execution.
+     */
+    @Override
+    public CommandResult execute(Model model) throws CommandException {
+        requireNonNull(model);
+
+        if (model.hasPerson(buyerToAdd)) {
+            throw new CommandException(MESSAGE_DUPLICATE_PERSON);
+        }
+
+        model.addPerson(buyerToAdd);
+        return new CommandResult(String.format(MESSAGE_SUCCESS, Messages.format(buyerToAdd)));
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        if (other == this) {
+            return true;
+        }
+
+        // instanceof handles nulls
+        if (!(other instanceof AddBuyerCommand)) {
+            return false;
+        }
+
+        AddBuyerCommand otherAddCommand = (AddBuyerCommand) other;
+        return buyerToAdd.equals(otherAddCommand.buyerToAdd);
+    }
+
+    @Override
+    public String toString() {
+        return new ToStringBuilder(this)
+                .add("buyerToAdd", buyerToAdd)
+                .toString();
+    }
+}

--- a/src/main/java/seedu/address/logic/commands/AddSellerCommand.java
+++ b/src/main/java/seedu/address/logic/commands/AddSellerCommand.java
@@ -1,0 +1,94 @@
+package seedu.address.logic.commands;
+
+import static java.util.Objects.requireNonNull;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_ADDRESS;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_EMAIL;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_NAME;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_PHONE;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_POSTALCODE;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_TAG;
+
+import seedu.address.commons.util.ToStringBuilder;
+import seedu.address.logic.Messages;
+import seedu.address.logic.commands.exceptions.CommandException;
+import seedu.address.model.Model;
+import seedu.address.model.person.Person;
+
+/**
+ * Adds a seller to the address book.
+ */
+public class AddSellerCommand extends Command {
+
+    public static final String COMMAND_WORD = "addseller";
+
+    public static final String MESSAGE_USAGE = COMMAND_WORD + ": Adds a seller to the address book. "
+            + "Parameters: "
+            + PREFIX_NAME + "NAME "
+            + PREFIX_PHONE + "PHONE "
+            + PREFIX_EMAIL + "EMAIL "
+            + PREFIX_ADDRESS + "ADDRESS "
+            + PREFIX_POSTALCODE + "POSTAL CODE "
+            + "[" + PREFIX_TAG + "TAG]...\n"
+            + "Example: " + COMMAND_WORD + " "
+            + PREFIX_NAME + "John Doe "
+            + PREFIX_PHONE + "98765432 "
+            + PREFIX_EMAIL + "johnd@example.com "
+            + PREFIX_ADDRESS + "311, Clementi Ave 2, #02-25 "
+            + PREFIX_POSTALCODE + "578578 "
+            + PREFIX_TAG + "friends "
+            + PREFIX_TAG + "owesMoney";
+
+    public static final String MESSAGE_SUCCESS = "New seller added: %1$s";
+    public static final String MESSAGE_DUPLICATE_PERSON = "This seller already exists in the address book";
+
+    private final Person sellerToAdd;
+
+    /**
+     * Creates an AddSellerCommand to add the specified seller.
+     * @param person The seller to be added.
+     */
+    public AddSellerCommand(Person person) {
+        requireNonNull(person);
+        sellerToAdd = person;
+    }
+    /**
+     * Executes the command and returns the result message.
+     *
+     * @param model {@code Model} which the command should operate on.
+     * @return feedback message of the operation result for display
+     * @throws CommandException If an error occurs during command execution.
+     */
+    @Override
+    public CommandResult execute(Model model) throws CommandException {
+        requireNonNull(model);
+
+        if (model.hasPerson(sellerToAdd)) {
+            throw new CommandException(MESSAGE_DUPLICATE_PERSON);
+        }
+
+        model.addPerson(sellerToAdd);
+        return new CommandResult(String.format(MESSAGE_SUCCESS, Messages.format(sellerToAdd)));
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        if (other == this) {
+            return true;
+        }
+
+        // instanceof handles nulls
+        if (!(other instanceof AddSellerCommand)) {
+            return false;
+        }
+
+        AddSellerCommand otherAddCommand = (AddSellerCommand) other;
+        return sellerToAdd.equals(otherAddCommand.sellerToAdd);
+    }
+
+    @Override
+    public String toString() {
+        return new ToStringBuilder(this)
+                .add("sellerToAdd", sellerToAdd)
+                .toString();
+    }
+}

--- a/src/main/java/seedu/address/logic/parser/AddBuyerCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddBuyerCommandParser.java
@@ -1,0 +1,66 @@
+package seedu.address.logic.parser;
+
+import static seedu.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_ADDRESS;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_EMAIL;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_NAME;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_PHONE;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_POSTALCODE;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_TAG;
+
+import java.util.Set;
+import java.util.stream.Stream;
+
+import seedu.address.logic.commands.AddBuyerCommand;
+import seedu.address.logic.parser.exceptions.ParseException;
+import seedu.address.model.house.PostalCode;
+import seedu.address.model.person.Address;
+import seedu.address.model.person.Email;
+import seedu.address.model.person.Name;
+import seedu.address.model.person.Person;
+import seedu.address.model.person.Phone;
+import seedu.address.model.tag.Tag;
+
+/**
+ * Parses input arguments and creates a new AddCommand object
+ */
+public class AddBuyerCommandParser implements Parser<AddBuyerCommand> {
+
+    /**
+     * Parses the given {@code String} of arguments in the context of the AddCommand
+     * and returns an AddCommand object for execution.
+     * @throws ParseException if the user input does not conform the expected format
+     */
+    public AddBuyerCommand parse(String args) throws ParseException {
+        ArgumentMultimap argMultimap =
+                ArgumentTokenizer.tokenize(args, PREFIX_NAME, PREFIX_PHONE, PREFIX_EMAIL, PREFIX_ADDRESS,
+                        PREFIX_POSTALCODE, PREFIX_TAG);
+
+        if (!arePrefixesPresent(argMultimap, PREFIX_NAME, PREFIX_ADDRESS, PREFIX_PHONE, PREFIX_EMAIL, PREFIX_POSTALCODE)
+                || !argMultimap.getPreamble().isEmpty()) {
+            throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, AddBuyerCommand.MESSAGE_USAGE));
+        }
+
+        argMultimap.verifyNoDuplicatePrefixesFor(PREFIX_NAME, PREFIX_PHONE, PREFIX_EMAIL,
+                PREFIX_ADDRESS, PREFIX_POSTALCODE);
+        Name name = ParserUtil.parseName(argMultimap.getValue(PREFIX_NAME).get());
+        Phone phone = ParserUtil.parsePhone(argMultimap.getValue(PREFIX_PHONE).get());
+        Email email = ParserUtil.parseEmail(argMultimap.getValue(PREFIX_EMAIL).get());
+        Address address = ParserUtil.parseAddress(argMultimap.getValue(PREFIX_ADDRESS).get());
+        PostalCode postalCode = ParserUtil.parsePostalCode(argMultimap.getValue(PREFIX_POSTALCODE).get());
+        Set<Tag> tagList = ParserUtil.parseTags(argMultimap.getAllValues(PREFIX_TAG));
+
+        Person person = new Person(name, phone, email, address, postalCode, tagList);
+
+        return new AddBuyerCommand(person);
+    }
+
+    /**
+     * Returns true if none of the prefixes contains empty {@code Optional} values in the given
+     * {@code ArgumentMultimap}.
+     */
+    private static boolean arePrefixesPresent(ArgumentMultimap argumentMultimap, Prefix... prefixes) {
+        return Stream.of(prefixes).allMatch(prefix -> argumentMultimap.getValue(prefix).isPresent());
+    }
+
+}

--- a/src/main/java/seedu/address/logic/parser/AddSellerCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddSellerCommandParser.java
@@ -1,0 +1,66 @@
+package seedu.address.logic.parser;
+
+import static seedu.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_ADDRESS;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_EMAIL;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_NAME;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_PHONE;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_POSTALCODE;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_TAG;
+
+import java.util.Set;
+import java.util.stream.Stream;
+
+import seedu.address.logic.commands.AddSellerCommand;
+import seedu.address.logic.parser.exceptions.ParseException;
+import seedu.address.model.house.PostalCode;
+import seedu.address.model.person.Address;
+import seedu.address.model.person.Email;
+import seedu.address.model.person.Name;
+import seedu.address.model.person.Person;
+import seedu.address.model.person.Phone;
+import seedu.address.model.tag.Tag;
+
+/**
+ * Parses input arguments and creates a new AddCommand object
+ */
+public class AddSellerCommandParser implements Parser<AddSellerCommand> {
+
+    /**
+     * Parses the given {@code String} of arguments in the context of the AddCommand
+     * and returns an AddCommand object for execution.
+     * @throws ParseException if the user input does not conform the expected format
+     */
+    public AddSellerCommand parse(String args) throws ParseException {
+        ArgumentMultimap argMultimap =
+                ArgumentTokenizer.tokenize(args, PREFIX_NAME, PREFIX_PHONE, PREFIX_EMAIL, PREFIX_ADDRESS,
+                        PREFIX_POSTALCODE, PREFIX_TAG);
+
+        if (!arePrefixesPresent(argMultimap, PREFIX_NAME, PREFIX_ADDRESS, PREFIX_PHONE, PREFIX_EMAIL, PREFIX_POSTALCODE)
+                || !argMultimap.getPreamble().isEmpty()) {
+            throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, AddSellerCommand.MESSAGE_USAGE));
+        }
+
+        argMultimap.verifyNoDuplicatePrefixesFor(PREFIX_NAME, PREFIX_PHONE, PREFIX_EMAIL,
+                PREFIX_ADDRESS, PREFIX_POSTALCODE);
+        Name name = ParserUtil.parseName(argMultimap.getValue(PREFIX_NAME).get());
+        Phone phone = ParserUtil.parsePhone(argMultimap.getValue(PREFIX_PHONE).get());
+        Email email = ParserUtil.parseEmail(argMultimap.getValue(PREFIX_EMAIL).get());
+        Address address = ParserUtil.parseAddress(argMultimap.getValue(PREFIX_ADDRESS).get());
+        PostalCode postalCode = ParserUtil.parsePostalCode(argMultimap.getValue(PREFIX_POSTALCODE).get());
+        Set<Tag> tagList = ParserUtil.parseTags(argMultimap.getAllValues(PREFIX_TAG));
+
+        Person person = new Person(name, phone, email, address, postalCode, tagList);
+
+        return new AddSellerCommand(person);
+    }
+
+    /**
+     * Returns true if none of the prefixes contains empty {@code Optional} values in the given
+     * {@code ArgumentMultimap}.
+     */
+    private static boolean arePrefixesPresent(ArgumentMultimap argumentMultimap, Prefix... prefixes) {
+        return Stream.of(prefixes).allMatch(prefix -> argumentMultimap.getValue(prefix).isPresent());
+    }
+
+}

--- a/src/main/java/seedu/address/logic/parser/AddressBookParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddressBookParser.java
@@ -8,7 +8,9 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 import seedu.address.commons.core.LogsCenter;
+import seedu.address.logic.commands.AddBuyerCommand;
 import seedu.address.logic.commands.AddCommand;
+import seedu.address.logic.commands.AddSellerCommand;
 import seedu.address.logic.commands.ClearCommand;
 import seedu.address.logic.commands.Command;
 import seedu.address.logic.commands.DeleteCommand;
@@ -55,6 +57,12 @@ public class AddressBookParser {
 
         case AddCommand.COMMAND_WORD:
             return new AddCommandParser().parse(arguments);
+
+        case AddSellerCommand.COMMAND_WORD:
+            return new AddSellerCommandParser().parse(arguments);
+
+        case AddBuyerCommand.COMMAND_WORD:
+            return new AddBuyerCommandParser().parse(arguments);
 
         case EditCommand.COMMAND_WORD:
             return new EditCommandParser().parse(arguments);

--- a/src/main/java/seedu/address/model/person/Buyer.java
+++ b/src/main/java/seedu/address/model/person/Buyer.java
@@ -1,0 +1,26 @@
+package seedu.address.model.person;
+
+import java.util.Set;
+
+import seedu.address.model.house.PostalCode;
+import seedu.address.model.tag.Tag;
+/**
+ * Represents a buyer in the address book.
+ */
+public class Buyer extends Person {
+
+    /**
+     * Constructs a new Buyer instance.
+     *
+     * @param name       The name of the buyer.
+     * @param phone      The phone number of the buyer.
+     * @param email      The email address of the buyer.
+     * @param address    The address of the buyer.
+     * @param postalCode The postal code of the buyer's address.
+     * @param tags       The tags associated with the buyer.
+     */
+    public Buyer(Name name, Phone phone, Email email, Address address, PostalCode postalCode, Set<Tag> tags) {
+        super(name, phone, email, address, postalCode, tags);
+    }
+}
+

--- a/src/main/java/seedu/address/model/person/Seller.java
+++ b/src/main/java/seedu/address/model/person/Seller.java
@@ -1,0 +1,26 @@
+package seedu.address.model.person;
+
+import java.util.Set;
+
+import seedu.address.model.house.PostalCode;
+import seedu.address.model.tag.Tag;
+
+/**
+ * Represents a seller in the address book.
+ */
+public class Seller extends Person {
+
+    /**
+     * Constructs a new Seller instance.
+     *
+     * @param name       The name of the seller.
+     * @param phone      The phone number of the seller.
+     * @param email      The email address of the seller.
+     * @param address    The address of the seller.
+     * @param postalCode The postal code of the seller's address.
+     * @param tags       The tags associated with the seller.
+     */
+    public Seller(Name name, Phone phone, Email email, Address address, PostalCode postalCode, Set<Tag> tags) {
+        super(name, phone, email, address, postalCode, tags);
+    }
+}

--- a/src/test/java/seedu/address/model/person/BuyerTest.java
+++ b/src/test/java/seedu/address/model/person/BuyerTest.java
@@ -1,0 +1,33 @@
+package seedu.address.model.person;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static seedu.address.testutil.TypicalPersons.ALICE;
+import static seedu.address.testutil.TypicalPersons.BOB;
+
+import org.junit.jupiter.api.Test;
+
+public class BuyerTest {
+    @Test
+    public void equals() {
+
+        Buyer buyerAlice =
+                new Buyer(ALICE.getName(), ALICE.getPhone(), ALICE.getEmail(), ALICE.getAddress(),
+                        ALICE.getPostalCode(), ALICE.getTags());
+        Buyer buyerBob =
+                new Buyer(BOB.getName(), BOB.getPhone(), BOB.getEmail(), BOB.getAddress(),
+                        BOB.getPostalCode(), BOB.getTags());
+
+        // same object -> returns true
+        assertTrue(buyerAlice.equals(buyerAlice));
+
+        // null -> returns false
+        assertFalse(buyerAlice.equals(null));
+
+        // different type -> returns false
+        assertFalse(buyerAlice.equals(5));
+
+        // different person -> returns false
+        assertFalse(buyerAlice.equals(buyerBob));
+    }
+}

--- a/src/test/java/seedu/address/model/person/SellerTest.java
+++ b/src/test/java/seedu/address/model/person/SellerTest.java
@@ -1,0 +1,33 @@
+package seedu.address.model.person;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static seedu.address.testutil.TypicalPersons.ALICE;
+import static seedu.address.testutil.TypicalPersons.BOB;
+
+import org.junit.jupiter.api.Test;
+
+public class SellerTest {
+    @Test
+    public void equals() {
+
+        Seller sellerAlice =
+                new Seller(ALICE.getName(), ALICE.getPhone(), ALICE.getEmail(), ALICE.getAddress(),
+                        ALICE.getPostalCode(), ALICE.getTags());
+        Seller sellerBob =
+                new Seller(BOB.getName(), BOB.getPhone(), BOB.getEmail(), BOB.getAddress(),
+                        BOB.getPostalCode(), BOB.getTags());
+
+        // same object -> returns true
+        assertTrue(sellerAlice.equals(sellerAlice));
+
+        // null -> returns false
+        assertFalse(sellerAlice.equals(null));
+
+        // different type -> returns false
+        assertFalse(sellerAlice.equals(5));
+
+        // different person -> returns false
+        assertFalse(sellerAlice.equals(sellerBob));
+    }
+}


### PR DESCRIPTION
Currently, there are no specific classes for representing sellers and buyers in the address book application.

To differentiate between sellers and buyers in the address book application and to allow for specific functionalities and attributes for each.

Two new classes, Seller and Buyer, are created as subclasses of the Person class. Each class has its own add command and test cases to ensure proper functionality.

Subclassing from the Person class allows for code reuse and maintains consistency in the application's design.
Separate classes enable distinct behavior and attributes for sellers and buyers.

The new classes adhere to the existing design patterns and principles in the address book application. Tests cover various scenarios to ensure the correctness of the implementations.