### PR TITLE
Fix bug caused by editing budget field only

### DIFF
--- a/src/main/java/seedu/address/logic/commands/EditBuyerCommand.java
+++ b/src/main/java/seedu/address/logic/commands/EditBuyerCommand.java
@@ -1,11 +1,7 @@
 package seedu.address.logic.commands;
 
 import static java.util.Objects.requireNonNull;
-import static seedu.address.logic.parser.CliSyntax.PREFIX_EMAIL;
-import static seedu.address.logic.parser.CliSyntax.PREFIX_HOUSING_TYPE;
-import static seedu.address.logic.parser.CliSyntax.PREFIX_NAME;
-import static seedu.address.logic.parser.CliSyntax.PREFIX_PHONE;
-import static seedu.address.logic.parser.CliSyntax.PREFIX_TAG;
+import static seedu.address.logic.parser.CliSyntax.*;
 import static seedu.address.model.Model.PREDICATE_SHOW_ALL_PERSONS;
 
 import java.util.Collections;
@@ -47,6 +43,7 @@ public class EditBuyerCommand extends Command {
             + "[" + PREFIX_PHONE + "PHONE] "
             + "[" + PREFIX_EMAIL + "EMAIL] "
             + "[" + PREFIX_HOUSING_TYPE + "HOUSING_TYPE] "
+            + "[" + PREFIX_BUDGET + "BUDGET] "
             + "[" + PREFIX_TAG + "TAG]...\n"
             + "Example: " + COMMAND_WORD + " 1 "
             + PREFIX_PHONE + "91234567 "
@@ -175,7 +172,7 @@ public class EditBuyerCommand extends Command {
          * Returns true if at least one field is edited.
          */
         public boolean isAnyFieldEdited() {
-            return CollectionUtil.isAnyNonNull(name, phone, email, housingType, tags);
+            return CollectionUtil.isAnyNonNull(name, phone, email, housingType, budget, tags);
         }
 
         public void setName(Name name) {


### PR DESCRIPTION
Previously, when edit buyer command is executed with only budget field, the system detects it as no field is edited.