### PR TITLE
Add buyer seller tags according to person type

### DIFF
--- a/src/main/java/seedu/address/logic/commands/AddBuyerCommand.java
+++ b/src/main/java/seedu/address/logic/commands/AddBuyerCommand.java
@@ -6,7 +6,6 @@ import static seedu.address.logic.parser.CliSyntax.PREFIX_EMAIL;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_HOUSING_TYPE;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_NAME;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_PHONE;
-import static seedu.address.logic.parser.CliSyntax.PREFIX_TAG;
 
 import seedu.address.commons.util.ToStringBuilder;
 import seedu.address.logic.Messages;
@@ -27,16 +26,13 @@ public class AddBuyerCommand extends Command {
             + PREFIX_PHONE + "PHONE "
             + PREFIX_EMAIL + "EMAIL "
             + PREFIX_BUDGET + "BUDGET "
-            + PREFIX_HOUSING_TYPE + "HOUSING_TYPE "
-            + "[" + PREFIX_TAG + "TAG]...\n"
+            + PREFIX_HOUSING_TYPE + "HOUSING_TYPE\n"
             + "Example: " + COMMAND_WORD + " "
             + PREFIX_NAME + "John Doe "
             + PREFIX_PHONE + "98765432 "
             + PREFIX_EMAIL + "johnd@example.com "
             + PREFIX_BUDGET + "99999900 "
-            + PREFIX_HOUSING_TYPE + "Hdb "
-            + PREFIX_TAG + "friends "
-            + PREFIX_TAG + "owesMoney";
+            + PREFIX_HOUSING_TYPE + "Hdb";
 
     public static final String MESSAGE_SUCCESS = "New buyer added: %1$s";
     public static final String MESSAGE_DUPLICATE_BUYER = "This person already exists in EstateEase";

--- a/src/main/java/seedu/address/logic/commands/AddSellerCommand.java
+++ b/src/main/java/seedu/address/logic/commands/AddSellerCommand.java
@@ -37,8 +37,7 @@ public class AddSellerCommand extends Command {
             + PREFIX_LEVEL + "LEVEL "
             + PREFIX_UNITNUMBER + "UNIT NUMBER "
             + PREFIX_POSTALCODE + "POSTAL CODE "
-            + PREFIX_PRICE + "PRICE "
-            + "[" + PREFIX_TAG + "TAG]...\n"
+            + PREFIX_PRICE + "PRICE\n"
             + "Example: " + COMMAND_WORD + " "
             + PREFIX_NAME + "John Doe "
             + PREFIX_PHONE + "98765432 "
@@ -49,9 +48,7 @@ public class AddSellerCommand extends Command {
             + PREFIX_LEVEL + "02 "
             + PREFIX_UNITNUMBER + "25 "
             + PREFIX_POSTALCODE + "578578 "
-            + PREFIX_PRICE + "999999999 "
-            + PREFIX_TAG + "friends "
-            + PREFIX_TAG + "owesMoney ";
+            + PREFIX_PRICE + "999999999";
 
     public static final String MESSAGE_SUCCESS = "New seller added= %1$s";
     public static final String MESSAGE_DUPLICATE_SELLER = "This person already exists in EstateEase";

--- a/src/main/java/seedu/address/logic/commands/AddSellerCommand.java
+++ b/src/main/java/seedu/address/logic/commands/AddSellerCommand.java
@@ -10,7 +10,6 @@ import static seedu.address.logic.parser.CliSyntax.PREFIX_PHONE;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_POSTALCODE;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_PRICE;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_STREET;
-import static seedu.address.logic.parser.CliSyntax.PREFIX_TAG;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_UNITNUMBER;
 
 import seedu.address.commons.util.ToStringBuilder;

--- a/src/main/java/seedu/address/logic/commands/EditBuyerCommand.java
+++ b/src/main/java/seedu/address/logic/commands/EditBuyerCommand.java
@@ -37,7 +37,7 @@ import seedu.address.model.tag.Tag;
  * Edits the details of an existing buyer in the EstateEase contacts.
  */
 public class EditBuyerCommand extends Command {
-    // TODO: Allow command to edit the budget of the buyer, or any other field that's yet to be added.
+
     public static final String COMMAND_WORD = "editBuyer";
 
     public static final String MESSAGE_USAGE = COMMAND_WORD + ": Edits the details of the buyer identified "

--- a/src/main/java/seedu/address/logic/commands/EditBuyerCommand.java
+++ b/src/main/java/seedu/address/logic/commands/EditBuyerCommand.java
@@ -115,10 +115,7 @@ public class EditBuyerCommand extends Command {
         HousingType updatedHousingType = editBuyerDescriptor.getHousingType()
                 .orElse(buyerToEdit.getPreferredHousingType());
 
-        // Tags are non-editable
-        Set<Tag> tags = buyerToEdit.getTags();
-
-        return new Buyer(updatedName, updatedPhone, updatedEmail, updatedBudget, updatedHousingType, tags);
+        return new Buyer(updatedName, updatedPhone, updatedEmail, updatedBudget, updatedHousingType);
     }
 
     @Override

--- a/src/main/java/seedu/address/logic/commands/EditBuyerCommand.java
+++ b/src/main/java/seedu/address/logic/commands/EditBuyerCommand.java
@@ -6,7 +6,6 @@ import static seedu.address.logic.parser.CliSyntax.PREFIX_EMAIL;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_HOUSING_TYPE;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_NAME;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_PHONE;
-import static seedu.address.logic.parser.CliSyntax.PREFIX_TAG;
 import static seedu.address.model.Model.PREDICATE_SHOW_ALL_PERSONS;
 
 import java.util.Collections;
@@ -48,8 +47,7 @@ public class EditBuyerCommand extends Command {
             + "[" + PREFIX_PHONE + "PHONE] "
             + "[" + PREFIX_EMAIL + "EMAIL] "
             + "[" + PREFIX_HOUSING_TYPE + "HOUSING_TYPE] "
-            + "[" + PREFIX_BUDGET + "BUDGET] "
-            + "[" + PREFIX_TAG + "TAG]...\n"
+            + "[" + PREFIX_BUDGET + "BUDGET]\n"
             + "Example: " + COMMAND_WORD + " 1 "
             + PREFIX_PHONE + "91234567 "
             + PREFIX_EMAIL + "johndoe@example.com";

--- a/src/main/java/seedu/address/logic/commands/EditBuyerCommand.java
+++ b/src/main/java/seedu/address/logic/commands/EditBuyerCommand.java
@@ -116,9 +116,11 @@ public class EditBuyerCommand extends Command {
         Budget updatedBudget = editBuyerDescriptor.getBudget().orElse(buyerToEdit.getBudget());
         HousingType updatedHousingType = editBuyerDescriptor.getHousingType()
                 .orElse(buyerToEdit.getPreferredHousingType());
-        Set<Tag> updatedTags = editBuyerDescriptor.getTags().orElse(buyerToEdit.getTags());
 
-        return new Buyer(updatedName, updatedPhone, updatedEmail, updatedBudget, updatedHousingType, updatedTags);
+        // Tags are non-editable
+        Set<Tag> tags = buyerToEdit.getTags();
+
+        return new Buyer(updatedName, updatedPhone, updatedEmail, updatedBudget, updatedHousingType, tags);
     }
 
     @Override
@@ -177,7 +179,7 @@ public class EditBuyerCommand extends Command {
          * Returns true if at least one field is edited.
          */
         public boolean isAnyFieldEdited() {
-            return CollectionUtil.isAnyNonNull(name, phone, email, housingType, budget, tags);
+            return CollectionUtil.isAnyNonNull(name, phone, email, housingType, budget);
         }
 
         public void setName(Name name) {

--- a/src/main/java/seedu/address/logic/commands/EditSellerCommand.java
+++ b/src/main/java/seedu/address/logic/commands/EditSellerCommand.java
@@ -21,7 +21,6 @@ import seedu.address.logic.Messages;
 import seedu.address.logic.commands.exceptions.CommandException;
 import seedu.address.model.Model;
 import seedu.address.model.house.House;
-import seedu.address.model.house.HousingType;
 import seedu.address.model.person.Email;
 import seedu.address.model.person.Name;
 import seedu.address.model.person.Person;
@@ -102,10 +101,12 @@ public class EditSellerCommand extends Command {
         Name updatedName = editSellerDescriptor.getName().orElse(sellerToEdit.getName());
         Phone updatedPhone = editSellerDescriptor.getPhone().orElse(sellerToEdit.getPhone());
         Email updatedEmail = editSellerDescriptor.getEmail().orElse(sellerToEdit.getEmail());
-        Set<Tag> updatedTags = editSellerDescriptor.getTags().orElse(sellerToEdit.getTags());
+
+        // Both tags and houses are non-editable
+        Set<Tag> tags = sellerToEdit.getTags();
         ArrayList<House> houses = sellerToEdit.getHouses();
 
-        return new Seller(updatedName, updatedPhone, updatedEmail, houses, updatedTags);
+        return new Seller(updatedName, updatedPhone, updatedEmail, houses, tags);
     }
 
     @Override
@@ -140,7 +141,6 @@ public class EditSellerCommand extends Command {
         private Name name;
         private Phone phone;
         private Email email;
-        private HousingType housingType;
         private Set<Tag> tags;
 
         public EditSellerDescriptor() {
@@ -154,7 +154,6 @@ public class EditSellerCommand extends Command {
             setName(toCopy.name);
             setPhone(toCopy.phone);
             setEmail(toCopy.email);
-            setHousingType(toCopy.housingType);
             setTags(toCopy.tags);
         }
 
@@ -163,7 +162,7 @@ public class EditSellerCommand extends Command {
          * Returns true if at least one field is edited.
          */
         public boolean isAnyFieldEdited() {
-            return CollectionUtil.isAnyNonNull(name, phone, email, housingType, tags);
+            return CollectionUtil.isAnyNonNull(name, phone, email, tags);
         }
 
         public void setName(Name name) {
@@ -188,14 +187,6 @@ public class EditSellerCommand extends Command {
 
         public Optional<Email> getEmail() {
             return Optional.ofNullable(email);
-        }
-
-        public void setHousingType(HousingType housingType) {
-            this.housingType = housingType;
-        }
-
-        public Optional<HousingType> getHousingType() {
-            return Optional.ofNullable(housingType);
         }
 
         /**
@@ -230,7 +221,6 @@ public class EditSellerCommand extends Command {
             return Objects.equals(name, otherEditSellerDescriptor.name)
                     && Objects.equals(phone, otherEditSellerDescriptor.phone)
                     && Objects.equals(email, otherEditSellerDescriptor.email)
-                    && Objects.equals(housingType, otherEditSellerDescriptor.housingType)
                     && Objects.equals(tags, otherEditSellerDescriptor.tags);
         }
 
@@ -240,7 +230,6 @@ public class EditSellerCommand extends Command {
                     .add("name", name)
                     .add("phone", phone)
                     .add("email", email)
-                    .add("housingType", housingType)
                     .add("tags", tags)
                     .toString();
         }

--- a/src/main/java/seedu/address/logic/commands/EditSellerCommand.java
+++ b/src/main/java/seedu/address/logic/commands/EditSellerCommand.java
@@ -162,6 +162,7 @@ public class EditSellerCommand extends Command {
          * Returns true if at least one field is edited.
          */
         public boolean isAnyFieldEdited() {
+            // TODO(TAG): Remove tags
             return CollectionUtil.isAnyNonNull(name, phone, email, tags);
         }
 

--- a/src/main/java/seedu/address/logic/commands/EditSellerCommand.java
+++ b/src/main/java/seedu/address/logic/commands/EditSellerCommand.java
@@ -102,11 +102,10 @@ public class EditSellerCommand extends Command {
         Phone updatedPhone = editSellerDescriptor.getPhone().orElse(sellerToEdit.getPhone());
         Email updatedEmail = editSellerDescriptor.getEmail().orElse(sellerToEdit.getEmail());
 
-        // Both tags and houses are non-editable
-        Set<Tag> tags = sellerToEdit.getTags();
+        // Houses are non-editable via editSellerCommand
         ArrayList<House> houses = sellerToEdit.getHouses();
 
-        return new Seller(updatedName, updatedPhone, updatedEmail, houses, tags);
+        return new Seller(updatedName, updatedPhone, updatedEmail, houses);
     }
 
     @Override

--- a/src/main/java/seedu/address/logic/commands/EditSellerCommand.java
+++ b/src/main/java/seedu/address/logic/commands/EditSellerCommand.java
@@ -41,7 +41,7 @@ public class EditSellerCommand extends Command {
             + "Parameters: INDEX (must be a positive integer) "
             + "[" + PREFIX_NAME + "NAME] "
             + "[" + PREFIX_PHONE + "PHONE] "
-            + "[" + PREFIX_EMAIL + "EMAIL] "
+            + "[" + PREFIX_EMAIL + "EMAIL]\n"
             + "Example: " + COMMAND_WORD + " 1 "
             + PREFIX_PHONE + "91234567 "
             + PREFIX_EMAIL + "johndoe@example.com";

--- a/src/main/java/seedu/address/logic/parser/AddBuyerCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddBuyerCommandParser.java
@@ -6,9 +6,7 @@ import static seedu.address.logic.parser.CliSyntax.PREFIX_EMAIL;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_HOUSING_TYPE;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_NAME;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_PHONE;
-import static seedu.address.logic.parser.CliSyntax.PREFIX_TAG;
 
-import java.util.Set;
 import java.util.stream.Stream;
 
 import seedu.address.logic.commands.AddBuyerCommand;
@@ -19,7 +17,6 @@ import seedu.address.model.person.Buyer;
 import seedu.address.model.person.Email;
 import seedu.address.model.person.Name;
 import seedu.address.model.person.Phone;
-import seedu.address.model.tag.Tag;
 
 /**
  * Parses input arguments and creates a new AddCommand object
@@ -34,7 +31,7 @@ public class AddBuyerCommandParser implements Parser<AddBuyerCommand> {
     public AddBuyerCommand parse(String args) throws ParseException {
         ArgumentMultimap argMultimap =
                 ArgumentTokenizer.tokenize(args, PREFIX_NAME, PREFIX_PHONE, PREFIX_EMAIL, PREFIX_HOUSING_TYPE,
-                        PREFIX_BUDGET, PREFIX_TAG);
+                        PREFIX_BUDGET);
 
         if (!arePrefixesPresent(argMultimap, PREFIX_NAME, PREFIX_PHONE, PREFIX_EMAIL, PREFIX_HOUSING_TYPE,
                 PREFIX_BUDGET)
@@ -48,10 +45,9 @@ public class AddBuyerCommandParser implements Parser<AddBuyerCommand> {
         Phone phone = ParserUtil.parsePhone(argMultimap.getValue(PREFIX_PHONE).get());
         Email email = ParserUtil.parseEmail(argMultimap.getValue(PREFIX_EMAIL).get());
         HousingType housingType = ParserUtil.parseHousing(argMultimap.getValue(PREFIX_HOUSING_TYPE).get());
-        Set<Tag> tagList = ParserUtil.parseTags(argMultimap.getAllValues(PREFIX_TAG));
         Budget budget = ParserUtil.parseBudget(argMultimap.getValue(PREFIX_BUDGET).get());
 
-        Buyer buyer = new Buyer(name, phone, email, budget, housingType, tagList);
+        Buyer buyer = new Buyer(name, phone, email, budget, housingType);
         return new AddBuyerCommand(buyer);
     }
 

--- a/src/main/java/seedu/address/logic/parser/AddSellerCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddSellerCommandParser.java
@@ -10,11 +10,9 @@ import static seedu.address.logic.parser.CliSyntax.PREFIX_PHONE;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_POSTALCODE;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_PRICE;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_STREET;
-import static seedu.address.logic.parser.CliSyntax.PREFIX_TAG;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_UNITNUMBER;
 
 import java.util.ArrayList;
-import java.util.Set;
 import java.util.stream.Stream;
 
 import seedu.address.logic.commands.AddSellerCommand;
@@ -34,7 +32,6 @@ import seedu.address.model.person.Email;
 import seedu.address.model.person.Name;
 import seedu.address.model.person.Phone;
 import seedu.address.model.person.Seller;
-import seedu.address.model.tag.Tag;
 
 /**
  * Parses input arguments and creates a new AddSellerCommand object
@@ -50,7 +47,7 @@ public class AddSellerCommandParser implements Parser<AddSellerCommand> {
         ArgumentMultimap argMultimap =
                 ArgumentTokenizer.tokenize(args, PREFIX_NAME, PREFIX_PHONE, PREFIX_EMAIL,
                         PREFIX_HOUSING_TYPE, PREFIX_LEVEL, PREFIX_BLOCK, PREFIX_STREET,
-                        PREFIX_UNITNUMBER, PREFIX_POSTALCODE, PREFIX_PRICE, PREFIX_TAG);
+                        PREFIX_UNITNUMBER, PREFIX_POSTALCODE, PREFIX_PRICE);
 
         if (!arePrefixesPresent(argMultimap, PREFIX_NAME, PREFIX_PHONE, PREFIX_EMAIL, PREFIX_HOUSING_TYPE,
                 PREFIX_POSTALCODE, PREFIX_STREET, PREFIX_UNITNUMBER,
@@ -66,13 +63,12 @@ public class AddSellerCommandParser implements Parser<AddSellerCommand> {
         Email email = ParserUtil.parseEmail(argMultimap.getValue(PREFIX_EMAIL).get());
         HousingType housingType = ParserUtil.parseHousing(argMultimap.getValue(PREFIX_HOUSING_TYPE).get());
         Price price = ParserUtil.parsePrice(argMultimap.getValue(PREFIX_PRICE).get());
-        Set<Tag> tagList = ParserUtil.parseTags(argMultimap.getAllValues(PREFIX_TAG));
 
         ArrayList<House> houses = new ArrayList<>();
         // Seperated out the methods to create hdb, condominium and landed (adhere to SLAP)
         houses.add(createHouse(argMultimap, housingType, price));
 
-        Seller seller = new Seller(name, phone, email, houses, tagList);
+        Seller seller = new Seller(name, phone, email, houses);
         return new AddSellerCommand(seller);
     }
 

--- a/src/main/java/seedu/address/logic/parser/EditBuyerCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/EditBuyerCommandParser.java
@@ -33,7 +33,7 @@ public class EditBuyerCommandParser implements Parser<EditBuyerCommand> {
         requireNonNull(args);
         ArgumentMultimap argMultimap =
                 ArgumentTokenizer.tokenize(args, PREFIX_NAME, PREFIX_PHONE, PREFIX_EMAIL, PREFIX_HOUSING_TYPE,
-                        PREFIX_BUDGET, PREFIX_TAG);
+                        PREFIX_BUDGET);
 
         Index index;
 

--- a/src/main/java/seedu/address/logic/parser/EditSellerCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/EditSellerCommandParser.java
@@ -3,7 +3,6 @@ package seedu.address.logic.parser;
 import static java.util.Objects.requireNonNull;
 import static seedu.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_EMAIL;
-import static seedu.address.logic.parser.CliSyntax.PREFIX_HOUSING_TYPE;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_NAME;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_PHONE;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_TAG;
@@ -32,8 +31,7 @@ public class EditSellerCommandParser implements Parser<EditSellerCommand> {
     public EditSellerCommand parse(String args) throws ParseException {
         requireNonNull(args);
         ArgumentMultimap argMultimap =
-                ArgumentTokenizer.tokenize(args, PREFIX_NAME, PREFIX_PHONE, PREFIX_EMAIL, PREFIX_HOUSING_TYPE,
-                        PREFIX_TAG);
+                ArgumentTokenizer.tokenize(args, PREFIX_NAME, PREFIX_PHONE, PREFIX_EMAIL);
 
         Index index;
 
@@ -45,7 +43,7 @@ public class EditSellerCommandParser implements Parser<EditSellerCommand> {
                     EditSellerCommand.MESSAGE_USAGE), pe);
         }
 
-        argMultimap.verifyNoDuplicatePrefixesFor(PREFIX_NAME, PREFIX_PHONE, PREFIX_EMAIL, PREFIX_HOUSING_TYPE);
+        argMultimap.verifyNoDuplicatePrefixesFor(PREFIX_NAME, PREFIX_PHONE, PREFIX_EMAIL);
 
         EditSellerDescriptor editSellerDescriptor = new EditSellerDescriptor();
 
@@ -57,10 +55,6 @@ public class EditSellerCommandParser implements Parser<EditSellerCommand> {
         }
         if (argMultimap.getValue(PREFIX_EMAIL).isPresent()) {
             editSellerDescriptor.setEmail(ParserUtil.parseEmail(argMultimap.getValue(PREFIX_EMAIL).get()));
-        }
-        if (argMultimap.getValue(PREFIX_HOUSING_TYPE).isPresent()) {
-            editSellerDescriptor.setHousingType(ParserUtil.parseHousing(argMultimap
-                    .getValue(PREFIX_HOUSING_TYPE).get()));
         }
 
         parseTagsForEdit(argMultimap.getAllValues(PREFIX_TAG)).ifPresent(editSellerDescriptor::setTags);

--- a/src/main/java/seedu/address/model/person/Buyer.java
+++ b/src/main/java/seedu/address/model/person/Buyer.java
@@ -1,11 +1,9 @@
 package seedu.address.model.person;
 
 import java.util.Objects;
-import java.util.Set;
 
 import seedu.address.commons.util.ToStringBuilder;
 import seedu.address.model.house.HousingType;
-import seedu.address.model.tag.Tag;
 
 /**
  * Represents a buyer in the address book.
@@ -22,11 +20,10 @@ public class Buyer extends Person {
      * @param phone       The phone number of the buyer.
      * @param email       The email address of the buyer.
      * @param preferredHousingType The type of housing the buyer wants.
-     * @param tags        The tags associated with the buyer.
      * @param budget      The budget of the buyer.
      */
-    public Buyer(Name name, Phone phone, Email email, Budget budget, HousingType preferredHousingType, Set<Tag> tags) {
-        super(name, phone, email, tags);
+    public Buyer(Name name, Phone phone, Email email, Budget budget, HousingType preferredHousingType) {
+        super(name, phone, email);
         this.preferredHousingType = preferredHousingType;
         this.budget = budget;
     }

--- a/src/main/java/seedu/address/model/person/Person.java
+++ b/src/main/java/seedu/address/model/person/Person.java
@@ -25,12 +25,19 @@ public class Person {
     /**
      * Every field must be present and not null.
      */
-    public Person(Name name, Phone phone, Email email, Set<Tag> tags) {
+    public Person(Name name, Phone phone, Email email) {
         requireAllNonNull(name, phone, email, tags);
         this.name = name;
         this.phone = phone;
         this.email = email;
-        this.tags.addAll(tags);
+
+        if (this instanceof Seller) {
+            this.tags.add(new Tag("Seller"));
+        }
+
+        if (this instanceof Buyer) {
+            this.tags.add(new Tag("Buyer"));
+        }
     }
 
     public Name getName() {

--- a/src/main/java/seedu/address/model/person/Seller.java
+++ b/src/main/java/seedu/address/model/person/Seller.java
@@ -1,10 +1,8 @@
 package seedu.address.model.person;
 
 import java.util.ArrayList;
-import java.util.Set;
 
 import seedu.address.model.house.House;
-import seedu.address.model.tag.Tag;
 
 /**
  * Represents a seller in the address book.
@@ -19,10 +17,9 @@ public class Seller extends Person {
      * @param phone       The phone number of the seller.
      * @param email       The email address of the seller.
      * @param houses      The houses the seller has (modified to accept a list of houses)
-     * @param tags        The tags associated with the seller.
      */
-    public Seller(Name name, Phone phone, Email email, ArrayList<House> houses, Set<Tag> tags) {
-        super(name, phone, email, tags);
+    public Seller(Name name, Phone phone, Email email, ArrayList<House> houses) {
+        super(name, phone, email);
         this.houses = houses;
     }
 

--- a/src/main/java/seedu/address/model/util/SampleDataUtil.java
+++ b/src/main/java/seedu/address/model/util/SampleDataUtil.java
@@ -33,13 +33,13 @@ public class SampleDataUtil {
         return new Buyer[]{
             new Buyer(new Name("Alex Yeoh"), new Phone("87438807"),
                         new Email("alexyeoh@example.com"), new Budget("100000"),
-                        new HousingType("Hdb"), getTagSet("Buyer")),
+                        new HousingType("Hdb")),
             new Buyer(new Name("Bernice Yu"), new Phone("99272758"),
                         new Email("berniceyu@example.com"), new Budget("200000"),
-                        new HousingType("Condominium"), getTagSet("colleagues", "Buyer")),
+                        new HousingType("Condominium")),
             new Buyer(new Name("Charlotte Oliveiro"), new Phone("93210283"),
                         new Email("charlotte@example.com"), new Budget("300000"),
-                        new HousingType("Hdb"), getTagSet("Buyer")),
+                        new HousingType("Hdb")),
         };
     }
 
@@ -58,14 +58,11 @@ public class SampleDataUtil {
 
         return new Seller[]{
             new Seller(new Name("David Li"), new Phone("91031282"),
-                        new Email("lidavid@example.com"), davidLiHouses,
-                        getTagSet("Seller")),
+                        new Email("lidavid@example.com"), davidLiHouses),
             new Seller(new Name("Irfan Ibrahim"), new Phone("92492021"),
-                        new Email("irfan@example.com"), irfanHouses,
-                        getTagSet("Seller")),
+                        new Email("irfan@example.com"), irfanHouses),
             new Seller(new Name("Roy Balakrishnan"), new Phone("92624417"),
-                        new Email("royb@example.com"), royHouses,
-                        getTagSet("Seller"))
+                        new Email("royb@example.com"), royHouses)
         };
     }
 

--- a/src/main/java/seedu/address/model/util/SampleDataUtil.java
+++ b/src/main/java/seedu/address/model/util/SampleDataUtil.java
@@ -33,13 +33,13 @@ public class SampleDataUtil {
         return new Buyer[]{
             new Buyer(new Name("Alex Yeoh"), new Phone("87438807"),
                         new Email("alexyeoh@example.com"), new Budget("100000"),
-                        new HousingType("Hdb"), getTagSet("friends")),
+                        new HousingType("Hdb"), getTagSet("Buyer")),
             new Buyer(new Name("Bernice Yu"), new Phone("99272758"),
                         new Email("berniceyu@example.com"), new Budget("200000"),
-                        new HousingType("Condominium"), getTagSet("colleagues", "friends")),
+                        new HousingType("Condominium"), getTagSet("colleagues", "Buyer")),
             new Buyer(new Name("Charlotte Oliveiro"), new Phone("93210283"),
                         new Email("charlotte@example.com"), new Budget("300000"),
-                        new HousingType("Hdb"), getTagSet("neighbours")),
+                        new HousingType("Hdb"), getTagSet("Buyer")),
         };
     }
 
@@ -59,13 +59,13 @@ public class SampleDataUtil {
         return new Seller[]{
             new Seller(new Name("David Li"), new Phone("91031282"),
                         new Email("lidavid@example.com"), davidLiHouses,
-                        getTagSet("family")),
+                        getTagSet("Seller")),
             new Seller(new Name("Irfan Ibrahim"), new Phone("92492021"),
                         new Email("irfan@example.com"), irfanHouses,
-                        getTagSet("classmates")),
+                        getTagSet("Seller")),
             new Seller(new Name("Roy Balakrishnan"), new Phone("92624417"),
                         new Email("royb@example.com"), royHouses,
-                        getTagSet("colleagues"))
+                        getTagSet("Seller"))
         };
     }
 

--- a/src/main/java/seedu/address/storage/JsonAdaptedBuyer.java
+++ b/src/main/java/seedu/address/storage/JsonAdaptedBuyer.java
@@ -1,6 +1,5 @@
 package seedu.address.storage;
 
-import java.util.HashSet;
 import java.util.List;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
@@ -69,6 +68,6 @@ public class JsonAdaptedBuyer extends JsonAdaptedPerson {
 
         Person person = super.toModelType();
         return new Buyer(person.getName(), person.getPhone(), person.getEmail(),
-                modelBudget, modelHousingType, new HashSet<>(person.getTags()));
+                modelBudget, modelHousingType);
     }
 }

--- a/src/main/java/seedu/address/storage/JsonAdaptedPerson.java
+++ b/src/main/java/seedu/address/storage/JsonAdaptedPerson.java
@@ -90,7 +90,7 @@ class JsonAdaptedPerson {
         final Email modelEmail = new Email(email);
 
         final Set<Tag> modelTags = new HashSet<>(personTags);
-        return new Person(modelName, modelPhone, modelEmail, modelTags);
+        return new Person(modelName, modelPhone, modelEmail);
     }
 
 }

--- a/src/main/java/seedu/address/storage/JsonAdaptedSeller.java
+++ b/src/main/java/seedu/address/storage/JsonAdaptedSeller.java
@@ -1,7 +1,6 @@
 package seedu.address.storage;
 
 import java.util.ArrayList;
-import java.util.HashSet;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -63,6 +62,6 @@ public class JsonAdaptedSeller extends JsonAdaptedPerson {
         }
 
         return new Seller(person.getName(), person.getPhone(),
-                person.getEmail(), sellerHouses, new HashSet<>(person.getTags()));
+                person.getEmail(), sellerHouses);
     }
 }

--- a/src/main/java/seedu/address/ui/PersonCard.java
+++ b/src/main/java/seedu/address/ui/PersonCard.java
@@ -58,8 +58,16 @@ public class PersonCard extends UiPart<Region> {
         email.setText(person.getEmail().value);
         person.getTags().stream()
                 .sorted(Comparator.comparing(tag -> tag.tagName))
-                .forEach(tag -> tags.getChildren().add(new Label(tag.tagName)));
-
+                .forEach(tag -> {
+                    Label tagLabel = new Label(tag.tagName);
+                    tagLabel.getStyleClass().add("label");
+                    if ("Seller".equals(tag.tagName)) {
+                        tagLabel.getStyleClass().add("tag-seller");
+                    } else if ("Buyer".equals(tag.tagName)) {
+                        tagLabel.getStyleClass().add("tag-buyer");
+                    }
+                    tags.getChildren().add(tagLabel);
+                });
         // Check if person is a Seller and display houses (For now, we assume only have seller have house)
         if (person instanceof Seller) {
             // Show no budget

--- a/src/main/java/seedu/address/ui/PersonCard.java
+++ b/src/main/java/seedu/address/ui/PersonCard.java
@@ -63,8 +63,12 @@ public class PersonCard extends UiPart<Region> {
                     tagLabel.getStyleClass().add("label");
                     if ("Seller".equals(tag.tagName)) {
                         tagLabel.getStyleClass().add("tag-seller");
+                        // TODO(UI): Change background colour value for buyer and seller
+                        cardPane.setStyle("-fx-background-color: #511bb5;");
                     } else if ("Buyer".equals(tag.tagName)) {
                         tagLabel.getStyleClass().add("tag-buyer");
+                        // TODO(UI): Change background colour value for buyer and seller
+                        cardPane.setStyle("-fx-background-color: #2b5d79;");
                     }
                     tags.getChildren().add(tagLabel);
                 });

--- a/src/main/resources/view/DarkTheme.css
+++ b/src/main/resources/view/DarkTheme.css
@@ -342,9 +342,16 @@
     -fx-vgap: 3;
 }
 
-#tags .label {
-    -fx-text-fill: white;
-    -fx-background-color: #3e7b91;
+.tag-seller {
+    -fx-background-color: #511BB5;
+    -fx-padding: 1 3 1 3;
+    -fx-border-radius: 2;
+    -fx-background-radius: 2;
+    -fx-font-size: 11;
+}
+
+.tag-buyer {
+    -fx-background-color: #B51B32;
     -fx-padding: 1 3 1 3;
     -fx-border-radius: 2;
     -fx-background-radius: 2;

--- a/src/main/resources/view/DarkTheme.css
+++ b/src/main/resources/view/DarkTheme.css
@@ -342,8 +342,9 @@
     -fx-vgap: 3;
 }
 
+/* TODO(UI): Change colour for seller and buyer tag */
 .tag-seller {
-    -fx-background-color: #511BB5;
+    -fx-background-color: #b51b7f;
     -fx-padding: 1 3 1 3;
     -fx-border-radius: 2;
     -fx-background-radius: 2;
@@ -351,7 +352,7 @@
 }
 
 .tag-buyer {
-    -fx-background-color: #B51B32;
+    -fx-background-color: #273aa1;
     -fx-padding: 1 3 1 3;
     -fx-border-radius: 2;
     -fx-background-radius: 2;

--- a/src/test/data/JsonSerializableAddressBookTest/typicalPersonsAddressBook.json
+++ b/src/test/data/JsonSerializableAddressBookTest/typicalPersonsAddressBook.json
@@ -15,7 +15,7 @@
         "price": "100000"
       }
     ],
-    "tags" : [ "friends" ]
+    "tags" : [ "Seller" ]
   }, {
     "name" : "Benson Meier",
     "phone" : "94351253",
@@ -30,7 +30,7 @@
         "price": "200000"
       }
     ],
-    "tags" : [ "friends" ]
+    "tags" : [ "Seller" ]
   }, {
     "name" : "Carl Kurz",
     "phone" : "95352563",
@@ -46,7 +46,7 @@
         "price": "300000"
       }
     ],
-    "tags" : [ ]
+    "tags" : [ "Seller" ]
   }, {
     "name" : "Daniel Meier",
     "phone" : "87652533",
@@ -62,7 +62,7 @@
         "price": "400000"
       }
     ],
-    "tags" : [ "friends" ]
+    "tags" : [ "Seller" ]
   }, {
     "name" : "Elle Meyer",
     "phone" : "9482224",
@@ -78,7 +78,7 @@
         "price": "500000"
       }
     ],
-    "tags" : [ ]
+    "tags" : [ "Seller" ]
   }, {
     "name" : "Fiona Kunz",
     "phone" : "9482427",
@@ -94,7 +94,7 @@
         "price": "600000"
       }
     ],
-    "tags" : [ ]
+    "tags" : [ "Seller" ]
   }, {
     "name" : "George Best",
     "phone" : "9482442",
@@ -110,7 +110,7 @@
         "price": "700000"
       }
     ],
-    "tags" : [ ]
+    "tags" : [ "Seller" ]
   } ],
   "buyers" : [ {
     "name" : "Ben Ten",
@@ -118,20 +118,20 @@
     "email" : "ben@example.com",
     "preferredHousingType" : "Condominium",
     "budget": "123000",
-    "tags" : [ "friend", "husband" ]
+    "tags" : [ "Buyer" ]
   }, {
     "name" : "Zack York",
     "phone" : "82937163",
     "email" : "zack@gmail.com",
     "preferredHousingType" : "Hdb",
     "budget": "400000",
-    "tags" : [ "friends" ]
+    "tags" : [ "Buyer" ]
   }, {
     "name" : "Zane York",
     "phone" : "82937163",
     "email" : "zack@gmail.com",
     "preferredHousingType" : "Hdb",
     "budget": "500000",
-    "tags" : [ "friends" ]
+    "tags" : [ "Buyer" ]
   } ]
 }

--- a/src/test/java/seedu/address/logic/commands/CommandTestUtil.java
+++ b/src/test/java/seedu/address/logic/commands/CommandTestUtil.java
@@ -56,8 +56,8 @@ public class CommandTestUtil {
     public static final String VALID_BUDGET_AMY = "999000";
     public static final String VALID_BUDGET_BOB = "1000000";
     public static final String VALID_BUDGET_BEN = "123000";
-    public static final String VALID_TAG_HUSBAND = "husband";
-    public static final String VALID_TAG_FRIEND = "friend";
+    public static final String VALID_TAG_BUYER = "Buyer";
+    public static final String VALID_TAG_SELLER = "Seller";
     public static final String VALID_BLOCK_AMY = "99B";
     public static final String VALID_BLOCK_BOB = "99A";
     public static final String VALID_LEVEL_AMY = "10";
@@ -76,10 +76,11 @@ public class CommandTestUtil {
     public static final String PHONE_DESC_BOB = " " + PREFIX_PHONE + VALID_PHONE_BOB;
     public static final String EMAIL_DESC_AMY = " " + PREFIX_EMAIL + VALID_EMAIL_AMY;
     public static final String EMAIL_DESC_BOB = " " + PREFIX_EMAIL + VALID_EMAIL_BOB;
+    public static final String TAG_DESC_BUYER = " " + PREFIX_TAG + VALID_TAG_BUYER;
+    public static final String TAG_DESC_SELLER = " " + PREFIX_TAG + VALID_TAG_SELLER;
+
     public static final String HOUSING_TYPE_DESC_AMY = " " + PREFIX_HOUSING_TYPE + VALID_HOUSING_TYPE_AMY;
     public static final String HOUSING_TYPE_DESC_BOB = " " + PREFIX_HOUSING_TYPE + VALID_HOUSING_TYPE_BOB;
-    public static final String TAG_DESC_FRIEND = " " + PREFIX_TAG + VALID_TAG_FRIEND;
-    public static final String TAG_DESC_HUSBAND = " " + PREFIX_TAG + VALID_TAG_HUSBAND;
     public static final String BLOCK_DESC_AMY = " " + PREFIX_BLOCK + VALID_BLOCK_AMY;
     public static final String BLOCK_DESC_BOB = " " + PREFIX_BLOCK + VALID_BLOCK_BOB;
     public static final String LEVEL_DESC_AMY = " " + PREFIX_LEVEL + VALID_LEVEL_AMY;
@@ -104,26 +105,26 @@ public class CommandTestUtil {
     public static final String PREAMBLE_WHITESPACE = "\t  \r  \n";
     public static final String PREAMBLE_NON_EMPTY = "NonEmptyPreamble";
 
-    public static final EditSellerCommand.EditSellerDescriptor DESC_AMY;
-    public static final EditSellerCommand.EditSellerDescriptor DESC_BOB;
+    public static final EditSellerCommand.EditSellerDescriptor DESC_SELLER_AMY;
+    public static final EditSellerCommand.EditSellerDescriptor DESC_SELLER_BOB;
 
     public static final EditBuyerCommand.EditBuyerDescriptor DESC_BUYER_AMY;
     public static final EditBuyerCommand.EditBuyerDescriptor DESC_BUYER_BOB;
 
 
     static {
-        DESC_AMY = new EditSellerDescriptorBuilder().withName(VALID_NAME_AMY)
-                .withPhone(VALID_PHONE_AMY).withEmail(VALID_EMAIL_AMY).withHousingType(VALID_HOUSING_TYPE_AMY)
-                .withTags(VALID_TAG_FRIEND).build();
-        DESC_BOB = new EditSellerDescriptorBuilder().withName(VALID_NAME_BOB)
-                .withPhone(VALID_PHONE_BOB).withEmail(VALID_EMAIL_BOB).withHousingType(VALID_HOUSING_TYPE_BOB)
-                .withTags(VALID_TAG_HUSBAND, VALID_TAG_FRIEND).build();
+        DESC_SELLER_AMY = new EditSellerDescriptorBuilder().withName(VALID_NAME_AMY)
+                .withPhone(VALID_PHONE_AMY).withEmail(VALID_EMAIL_AMY)
+                .withTags(VALID_TAG_SELLER).build();
+        DESC_SELLER_BOB = new EditSellerDescriptorBuilder().withName(VALID_NAME_BOB)
+                .withPhone(VALID_PHONE_BOB).withEmail(VALID_EMAIL_BOB)
+                .withTags(VALID_TAG_SELLER).build();
         DESC_BUYER_AMY = new EditBuyerDescriptorBuilder().withName(VALID_NAME_AMY)
-                .withPhone(VALID_PHONE_AMY).withEmail(VALID_EMAIL_AMY).withHousingType(VALID_HOUSING_TYPE_AMY)
-                .withTags(VALID_TAG_FRIEND).build();
+                .withPhone(VALID_PHONE_AMY).withEmail(VALID_EMAIL_AMY)
+                .withTags(VALID_TAG_BUYER).build();
         DESC_BUYER_BOB = new EditBuyerDescriptorBuilder().withName(VALID_NAME_BOB)
-                .withPhone(VALID_PHONE_BOB).withEmail(VALID_EMAIL_BOB).withHousingType(VALID_HOUSING_TYPE_BOB)
-                .withTags(VALID_TAG_HUSBAND, VALID_TAG_FRIEND).build();
+                .withPhone(VALID_PHONE_BOB).withEmail(VALID_EMAIL_BOB)
+                .withTags(VALID_TAG_BUYER).build();
     }
 
     /**

--- a/src/test/java/seedu/address/logic/commands/EditBuyerCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/EditBuyerCommandTest.java
@@ -7,7 +7,7 @@ import static seedu.address.logic.commands.CommandTestUtil.DESC_BUYER_AMY;
 import static seedu.address.logic.commands.CommandTestUtil.DESC_BUYER_BOB;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_NAME_BOB;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_PHONE_BOB;
-import static seedu.address.logic.commands.CommandTestUtil.VALID_TAG_HUSBAND;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_TAG_BUYER;
 import static seedu.address.logic.commands.CommandTestUtil.assertCommandFailure;
 import static seedu.address.logic.commands.CommandTestUtil.assertCommandSuccess;
 import static seedu.address.logic.commands.CommandTestUtil.showPersonAtIndex;
@@ -75,10 +75,10 @@ public class EditBuyerCommandTest {
 
         BuyerBuilder buyerInList = new BuyerBuilder(lastBuyer);
         Buyer editedBuyer = buyerInList.withName(VALID_NAME_BOB).withPhone(VALID_PHONE_BOB)
-                .withTags(VALID_TAG_HUSBAND).build();
+                .withTags(VALID_TAG_BUYER).build();
 
         EditBuyerDescriptor descriptor = new EditBuyerDescriptorBuilder().withName(VALID_NAME_BOB)
-                .withPhone(VALID_PHONE_BOB).withTags(VALID_TAG_HUSBAND).build();
+                .withPhone(VALID_PHONE_BOB).withTags(VALID_TAG_BUYER).build();
         EditBuyerCommand editBuyerCommand = new EditBuyerCommand(indexLastBuyer, descriptor);
 
         String expectedMessage = String.format(EditBuyerCommand.MESSAGE_EDIT_BUYER_SUCCESS,

--- a/src/test/java/seedu/address/logic/commands/EditBuyerCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/EditBuyerCommandTest.java
@@ -7,7 +7,6 @@ import static seedu.address.logic.commands.CommandTestUtil.DESC_BUYER_AMY;
 import static seedu.address.logic.commands.CommandTestUtil.DESC_BUYER_BOB;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_NAME_BOB;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_PHONE_BOB;
-import static seedu.address.logic.commands.CommandTestUtil.VALID_TAG_BUYER;
 import static seedu.address.logic.commands.CommandTestUtil.assertCommandFailure;
 import static seedu.address.logic.commands.CommandTestUtil.assertCommandSuccess;
 import static seedu.address.logic.commands.CommandTestUtil.showPersonAtIndex;
@@ -74,11 +73,10 @@ public class EditBuyerCommandTest {
         Buyer lastBuyer = (Buyer) model.getFilteredPersonList().get(indexLastBuyer.getZeroBased());
 
         BuyerBuilder buyerInList = new BuyerBuilder(lastBuyer);
-        Buyer editedBuyer = buyerInList.withName(VALID_NAME_BOB).withPhone(VALID_PHONE_BOB)
-                .withTags(VALID_TAG_BUYER).build();
+        Buyer editedBuyer = buyerInList.withName(VALID_NAME_BOB).withPhone(VALID_PHONE_BOB).build();
 
         EditBuyerDescriptor descriptor = new EditBuyerDescriptorBuilder().withName(VALID_NAME_BOB)
-                .withPhone(VALID_PHONE_BOB).withTags(VALID_TAG_BUYER).build();
+                .withPhone(VALID_PHONE_BOB).build();
         EditBuyerCommand editBuyerCommand = new EditBuyerCommand(indexLastBuyer, descriptor);
 
         String expectedMessage = String.format(EditBuyerCommand.MESSAGE_EDIT_BUYER_SUCCESS,

--- a/src/test/java/seedu/address/logic/commands/EditBuyerDescriptorTest.java
+++ b/src/test/java/seedu/address/logic/commands/EditBuyerDescriptorTest.java
@@ -9,7 +9,7 @@ import static seedu.address.logic.commands.CommandTestUtil.VALID_EMAIL_BOB;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_HOUSING_TYPE_BOB;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_NAME_BOB;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_PHONE_BOB;
-import static seedu.address.logic.commands.CommandTestUtil.VALID_TAG_HUSBAND;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_TAG_SELLER;
 
 import org.junit.jupiter.api.Test;
 
@@ -53,7 +53,7 @@ public class EditBuyerDescriptorTest {
         assertFalse(DESC_BUYER_AMY.equals(editedAmy));
 
         // different tags -> returns false
-        editedAmy = new EditBuyerDescriptorBuilder(DESC_BUYER_AMY).withTags(VALID_TAG_HUSBAND).build();
+        editedAmy = new EditBuyerDescriptorBuilder(DESC_BUYER_AMY).withTags(VALID_TAG_SELLER).build();
         assertFalse(DESC_BUYER_AMY.equals(editedAmy));
     }
 

--- a/src/test/java/seedu/address/logic/commands/EditSellerCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/EditSellerCommandTest.java
@@ -3,11 +3,11 @@ package seedu.address.logic.commands;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
-import static seedu.address.logic.commands.CommandTestUtil.DESC_AMY;
-import static seedu.address.logic.commands.CommandTestUtil.DESC_BOB;
+import static seedu.address.logic.commands.CommandTestUtil.DESC_SELLER_AMY;
+import static seedu.address.logic.commands.CommandTestUtil.DESC_SELLER_BOB;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_NAME_BOB;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_PHONE_BOB;
-import static seedu.address.logic.commands.CommandTestUtil.VALID_TAG_HUSBAND;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_TAG_SELLER;
 import static seedu.address.logic.commands.CommandTestUtil.assertCommandFailure;
 import static seedu.address.logic.commands.CommandTestUtil.assertCommandSuccess;
 import static seedu.address.logic.commands.CommandTestUtil.showPersonAtIndex;
@@ -63,7 +63,6 @@ public class EditSellerCommandTest {
 
         Model expectedModel = new ModelManager(new AddressBook(model.getAddressBook()), new UserPrefs());
         expectedModel.setPerson(model.getFilteredPersonList().get(INDEX_FIRST_PERSON.getZeroBased()), editedSeller);
-        // TODO: INDEX_FIRST_PERSON?
         assertCommandFailure(editSellerCommand, model, expectedMessage);
     }
 
@@ -74,10 +73,10 @@ public class EditSellerCommandTest {
 
         SellerBuilder sellerInList = new SellerBuilder(firstSeller);
         Seller editedSeller = sellerInList.withName(VALID_NAME_BOB).withPhone(VALID_PHONE_BOB)
-                .withTags(VALID_TAG_HUSBAND).build();
+                .withTags(VALID_TAG_SELLER).build();
 
         EditSellerDescriptor descriptor = new EditSellerDescriptorBuilder().withName(VALID_NAME_BOB)
-                .withPhone(VALID_PHONE_BOB).withTags(VALID_TAG_HUSBAND).build();
+                .withPhone(VALID_PHONE_BOB).withTags(VALID_TAG_SELLER).build();
         EditSellerCommand editSellerCommand = new EditSellerCommand(INDEX_FIRST_PERSON, descriptor);
 
         String expectedMessage = String.format(EditSellerCommand.MESSAGE_EDIT_SELLER_SUCCESS,
@@ -171,10 +170,10 @@ public class EditSellerCommandTest {
 
     @Test
     public void equals() {
-        final EditSellerCommand standardCommand = new EditSellerCommand(INDEX_FIRST_PERSON, DESC_AMY);
+        final EditSellerCommand standardCommand = new EditSellerCommand(INDEX_FIRST_PERSON, DESC_SELLER_AMY);
 
         // same values -> returns true
-        EditSellerDescriptor copyDescriptor = new EditSellerDescriptor(DESC_AMY);
+        EditSellerDescriptor copyDescriptor = new EditSellerDescriptor(DESC_SELLER_AMY);
         EditSellerCommand commandWithSameValues = new EditSellerCommand(INDEX_FIRST_PERSON, copyDescriptor);
         assertTrue(standardCommand.equals(commandWithSameValues));
 
@@ -188,10 +187,10 @@ public class EditSellerCommandTest {
         assertFalse(standardCommand.equals(new ClearCommand()));
 
         // different index -> returns false
-        assertFalse(standardCommand.equals(new EditSellerCommand(INDEX_SECOND_PERSON, DESC_AMY)));
+        assertFalse(standardCommand.equals(new EditSellerCommand(INDEX_SECOND_PERSON, DESC_SELLER_AMY)));
 
         // different descriptor -> returns false
-        assertFalse(standardCommand.equals(new EditSellerCommand(INDEX_FIRST_PERSON, DESC_BOB)));
+        assertFalse(standardCommand.equals(new EditSellerCommand(INDEX_FIRST_PERSON, DESC_SELLER_BOB)));
     }
 
     @Test

--- a/src/test/java/seedu/address/logic/commands/EditSellerDescriptorTest.java
+++ b/src/test/java/seedu/address/logic/commands/EditSellerDescriptorTest.java
@@ -3,13 +3,12 @@ package seedu.address.logic.commands;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
-import static seedu.address.logic.commands.CommandTestUtil.DESC_AMY;
-import static seedu.address.logic.commands.CommandTestUtil.DESC_BOB;
+import static seedu.address.logic.commands.CommandTestUtil.DESC_SELLER_AMY;
+import static seedu.address.logic.commands.CommandTestUtil.DESC_SELLER_BOB;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_EMAIL_BOB;
-import static seedu.address.logic.commands.CommandTestUtil.VALID_HOUSING_TYPE_BOB;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_NAME_BOB;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_PHONE_BOB;
-import static seedu.address.logic.commands.CommandTestUtil.VALID_TAG_HUSBAND;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_TAG_BUYER;
 
 import org.junit.jupiter.api.Test;
 
@@ -21,40 +20,37 @@ public class EditSellerDescriptorTest {
     @Test
     public void equals() {
         // same values -> returns true
-        EditSellerDescriptor descriptorWithSameValues = new EditSellerDescriptor(DESC_AMY);
-        assertTrue(DESC_AMY.equals(descriptorWithSameValues));
+        EditSellerDescriptor descriptorWithSameValues = new EditSellerDescriptor(DESC_SELLER_AMY);
+        assertTrue(DESC_SELLER_AMY.equals(descriptorWithSameValues));
 
         // same object -> returns true
-        assertTrue(DESC_AMY.equals(DESC_AMY));
+        assertTrue(DESC_SELLER_AMY.equals(DESC_SELLER_AMY));
 
         // null -> returns false
-        assertFalse(DESC_AMY.equals(null));
+        assertFalse(DESC_SELLER_AMY.equals(null));
 
         // different types -> returns false
-        assertFalse(DESC_AMY.equals(5));
+        assertFalse(DESC_SELLER_AMY.equals(5));
 
         // different values -> returns false
-        assertFalse(DESC_AMY.equals(DESC_BOB));
+        assertFalse(DESC_SELLER_AMY.equals(DESC_SELLER_BOB));
 
         // different name -> returns false
-        EditSellerDescriptor editedAmy = new EditSellerDescriptorBuilder(DESC_AMY).withName(VALID_NAME_BOB).build();
-        assertFalse(DESC_AMY.equals(editedAmy));
+        EditSellerDescriptor editedAmy = new EditSellerDescriptorBuilder(DESC_SELLER_AMY)
+                .withName(VALID_NAME_BOB).build();
+        assertFalse(DESC_SELLER_AMY.equals(editedAmy));
 
         // different phone -> returns false
-        editedAmy = new EditSellerDescriptorBuilder(DESC_AMY).withPhone(VALID_PHONE_BOB).build();
-        assertFalse(DESC_AMY.equals(editedAmy));
+        editedAmy = new EditSellerDescriptorBuilder(DESC_SELLER_AMY).withPhone(VALID_PHONE_BOB).build();
+        assertFalse(DESC_SELLER_AMY.equals(editedAmy));
 
         // different email -> returns false
-        editedAmy = new EditSellerDescriptorBuilder(DESC_AMY).withEmail(VALID_EMAIL_BOB).build();
-        assertFalse(DESC_AMY.equals(editedAmy));
-
-        // different address -> returns false
-        editedAmy = new EditSellerDescriptorBuilder(DESC_AMY).withHousingType(VALID_HOUSING_TYPE_BOB).build();
-        assertFalse(DESC_AMY.equals(editedAmy));
+        editedAmy = new EditSellerDescriptorBuilder(DESC_SELLER_AMY).withEmail(VALID_EMAIL_BOB).build();
+        assertFalse(DESC_SELLER_AMY.equals(editedAmy));
 
         // different tags -> returns false
-        editedAmy = new EditSellerDescriptorBuilder(DESC_AMY).withTags(VALID_TAG_HUSBAND).build();
-        assertFalse(DESC_AMY.equals(editedAmy));
+        editedAmy = new EditSellerDescriptorBuilder(DESC_SELLER_AMY).withTags(VALID_TAG_BUYER).build();
+        assertFalse(DESC_SELLER_AMY.equals(editedAmy));
     }
 
     @Test
@@ -64,7 +60,6 @@ public class EditSellerDescriptorTest {
                 + "{name=" + editSellerDescriptor.getName().orElse(null)
                 + ", phone=" + editSellerDescriptor.getPhone().orElse(null)
                 + ", email=" + editSellerDescriptor.getEmail().orElse(null)
-                + ", housingType=" + editSellerDescriptor.getHousingType().orElse(null)
                 + ", tags=" + editSellerDescriptor.getTags().orElse(null) + "}";
         assertEquals(expected, editSellerDescriptor.toString());
     }

--- a/src/test/java/seedu/address/logic/parser/AddressBookParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/AddressBookParserTest.java
@@ -27,7 +27,7 @@ import seedu.address.logic.commands.ListCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
 import seedu.address.model.person.Buyer;
 import seedu.address.model.person.NameContainsKeywordsPredicate;
-import seedu.address.model.person.Person;
+import seedu.address.model.person.Seller;
 import seedu.address.testutil.BuyerBuilder;
 import seedu.address.testutil.EditBuyerDescriptorBuilder;
 import seedu.address.testutil.EditSellerDescriptorBuilder;
@@ -59,11 +59,11 @@ public class AddressBookParserTest {
     }
 
     @Test
-    public void parseCommand_edit() throws Exception {
-        Person person = new SellerBuilder().build();
-        EditSellerDescriptor descriptor = new EditSellerDescriptorBuilder(person).build();
-        EditSellerCommand command = (EditSellerCommand) parser.parseCommand(EditSellerCommand.COMMAND_WORD + " "
-                + INDEX_FIRST_PERSON.getOneBased() + " " + PersonUtil.getEditPersonDescriptorDetails(descriptor));
+    public void parseCommand_editSeller() throws Exception {
+        Seller seller = new SellerBuilder().build();
+        EditSellerDescriptor descriptor = new EditSellerDescriptorBuilder(seller).build();
+        EditSellerCommand command = (EditSellerCommand) parser.parseCommand(EditSellerCommand.COMMAND_WORD
+                + " " + INDEX_FIRST_PERSON.getOneBased() + " " + PersonUtil.getEditSellerDescriptorDetails(descriptor));
         assertEquals(new EditSellerCommand(INDEX_FIRST_PERSON, descriptor), command);
     }
 

--- a/src/test/java/seedu/address/logic/parser/EditBuyerCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/EditBuyerCommandParserTest.java
@@ -9,11 +9,9 @@ import static seedu.address.logic.commands.CommandTestUtil.INVALID_EMAIL_DESC;
 import static seedu.address.logic.commands.CommandTestUtil.INVALID_HOUSING_TYPE_DESC;
 import static seedu.address.logic.commands.CommandTestUtil.INVALID_NAME_DESC;
 import static seedu.address.logic.commands.CommandTestUtil.INVALID_PHONE_DESC;
-import static seedu.address.logic.commands.CommandTestUtil.INVALID_TAG_DESC;
 import static seedu.address.logic.commands.CommandTestUtil.NAME_DESC_AMY;
 import static seedu.address.logic.commands.CommandTestUtil.PHONE_DESC_AMY;
 import static seedu.address.logic.commands.CommandTestUtil.PHONE_DESC_BOB;
-import static seedu.address.logic.commands.CommandTestUtil.TAG_DESC_BUYER;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_EMAIL_AMY;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_HOUSING_TYPE_AMY;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_NAME_AMY;
@@ -23,7 +21,6 @@ import static seedu.address.logic.commands.CommandTestUtil.VALID_TAG_BUYER;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_EMAIL;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_HOUSING_TYPE;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_PHONE;
-import static seedu.address.logic.parser.CliSyntax.PREFIX_TAG;
 import static seedu.address.logic.parser.CommandParserTestUtil.assertParseFailure;
 import static seedu.address.logic.parser.CommandParserTestUtil.assertParseSuccess;
 import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST_PERSON;
@@ -40,11 +37,8 @@ import seedu.address.model.house.House;
 import seedu.address.model.person.Email;
 import seedu.address.model.person.Name;
 import seedu.address.model.person.Phone;
-import seedu.address.model.tag.Tag;
 import seedu.address.testutil.EditBuyerDescriptorBuilder;
 public class EditBuyerCommandParserTest {
-
-    private static final String TAG_EMPTY = " " + PREFIX_TAG;
 
     private static final String MESSAGE_INVALID_FORMAT =
             String.format(MESSAGE_INVALID_COMMAND_FORMAT, EditBuyerCommand.MESSAGE_USAGE);
@@ -84,7 +78,6 @@ public class EditBuyerCommandParserTest {
         assertParseFailure(parser, "1" + INVALID_PHONE_DESC, Phone.MESSAGE_CONSTRAINTS); // invalid phone
         assertParseFailure(parser, "1" + INVALID_EMAIL_DESC, Email.MESSAGE_CONSTRAINTS); // invalid email
         assertParseFailure(parser, "1" + INVALID_HOUSING_TYPE_DESC, House.MESSAGE_CONSTRAINTS);
-        assertParseFailure(parser, "1" + INVALID_TAG_DESC, Tag.MESSAGE_CONSTRAINTS); // invalid tag
 
         // invalid phone followed by valid email
         assertParseFailure(parser, "1" + INVALID_PHONE_DESC + EMAIL_DESC_AMY, Phone.MESSAGE_CONSTRAINTS);
@@ -99,11 +92,10 @@ public class EditBuyerCommandParserTest {
     public void parse_allFieldsSpecified_success() {
         Index targetIndex = INDEX_SECOND_PERSON;
         String userInput = targetIndex.getOneBased() + PHONE_DESC_BOB + EMAIL_DESC_AMY
-                + HOUSING_TYPE_DESC_AMY + NAME_DESC_AMY + TAG_DESC_BUYER;
+                + HOUSING_TYPE_DESC_AMY + NAME_DESC_AMY;
 
         EditBuyerDescriptor descriptor = new EditBuyerDescriptorBuilder().withName(VALID_NAME_AMY)
-                .withPhone(VALID_PHONE_BOB).withEmail(VALID_EMAIL_AMY).withHousingType(VALID_HOUSING_TYPE_AMY)
-                .withTags(VALID_TAG_BUYER).build();
+                .withPhone(VALID_PHONE_BOB).withEmail(VALID_EMAIL_AMY).withHousingType(VALID_HOUSING_TYPE_AMY).build();
         EditBuyerCommand expectedCommand = new EditBuyerCommand(targetIndex, descriptor);
 
         assertParseSuccess(parser, userInput, expectedCommand);
@@ -147,12 +139,6 @@ public class EditBuyerCommandParserTest {
         descriptor = new EditBuyerDescriptorBuilder().withHousingType(VALID_HOUSING_TYPE_AMY).build();
         expectedCommand = new EditBuyerCommand(targetIndex, descriptor);
         assertParseSuccess(parser, userInput, expectedCommand);
-
-        // tags
-        userInput = targetIndex.getOneBased() + TAG_DESC_BUYER;
-        descriptor = new EditBuyerDescriptorBuilder().withTags(VALID_TAG_BUYER).build();
-        expectedCommand = new EditBuyerCommand(targetIndex, descriptor);
-        assertParseSuccess(parser, userInput, expectedCommand);
     }
 
     @Test
@@ -185,16 +171,5 @@ public class EditBuyerCommandParserTest {
 
         assertParseFailure(parser, userInput,
                 Messages.getErrorMessageForDuplicatePrefixes(PREFIX_PHONE, PREFIX_EMAIL, PREFIX_HOUSING_TYPE));
-    }
-
-    @Test
-    public void parse_resetTags_success() {
-        Index targetIndex = INDEX_THIRD_PERSON;
-        String userInput = targetIndex.getOneBased() + TAG_EMPTY;
-
-        EditBuyerDescriptor descriptor = new EditBuyerDescriptorBuilder().withTags().build();
-        EditBuyerCommand expectedCommand = new EditBuyerCommand(targetIndex, descriptor);
-
-        assertParseSuccess(parser, userInput, expectedCommand);
     }
 }

--- a/src/test/java/seedu/address/logic/parser/EditBuyerCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/EditBuyerCommandParserTest.java
@@ -13,15 +13,13 @@ import static seedu.address.logic.commands.CommandTestUtil.INVALID_TAG_DESC;
 import static seedu.address.logic.commands.CommandTestUtil.NAME_DESC_AMY;
 import static seedu.address.logic.commands.CommandTestUtil.PHONE_DESC_AMY;
 import static seedu.address.logic.commands.CommandTestUtil.PHONE_DESC_BOB;
-import static seedu.address.logic.commands.CommandTestUtil.TAG_DESC_FRIEND;
-import static seedu.address.logic.commands.CommandTestUtil.TAG_DESC_HUSBAND;
+import static seedu.address.logic.commands.CommandTestUtil.TAG_DESC_BUYER;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_EMAIL_AMY;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_HOUSING_TYPE_AMY;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_NAME_AMY;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_PHONE_AMY;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_PHONE_BOB;
-import static seedu.address.logic.commands.CommandTestUtil.VALID_TAG_FRIEND;
-import static seedu.address.logic.commands.CommandTestUtil.VALID_TAG_HUSBAND;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_TAG_BUYER;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_EMAIL;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_HOUSING_TYPE;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_PHONE;
@@ -91,12 +89,6 @@ public class EditBuyerCommandParserTest {
         // invalid phone followed by valid email
         assertParseFailure(parser, "1" + INVALID_PHONE_DESC + EMAIL_DESC_AMY, Phone.MESSAGE_CONSTRAINTS);
 
-        // while parsing {@code PREFIX_TAG} alone will reset the tags of the {@code Person} being edited,
-        // parsing it together with a valid tag results in error
-        assertParseFailure(parser, "1" + TAG_DESC_FRIEND + TAG_DESC_HUSBAND + TAG_EMPTY, Tag.MESSAGE_CONSTRAINTS);
-        assertParseFailure(parser, "1" + TAG_DESC_FRIEND + TAG_EMPTY + TAG_DESC_HUSBAND, Tag.MESSAGE_CONSTRAINTS);
-        assertParseFailure(parser, "1" + TAG_EMPTY + TAG_DESC_FRIEND + TAG_DESC_HUSBAND, Tag.MESSAGE_CONSTRAINTS);
-
         // multiple invalid values, but only the first invalid value is captured
         assertParseFailure(parser, "1" + INVALID_NAME_DESC + INVALID_EMAIL_DESC + VALID_HOUSING_TYPE_AMY
                         + VALID_PHONE_AMY,
@@ -106,12 +98,12 @@ public class EditBuyerCommandParserTest {
     @Test
     public void parse_allFieldsSpecified_success() {
         Index targetIndex = INDEX_SECOND_PERSON;
-        String userInput = targetIndex.getOneBased() + PHONE_DESC_BOB + TAG_DESC_HUSBAND
-                + EMAIL_DESC_AMY + HOUSING_TYPE_DESC_AMY + NAME_DESC_AMY + TAG_DESC_FRIEND;
+        String userInput = targetIndex.getOneBased() + PHONE_DESC_BOB + EMAIL_DESC_AMY
+                + HOUSING_TYPE_DESC_AMY + NAME_DESC_AMY + TAG_DESC_BUYER;
 
         EditBuyerDescriptor descriptor = new EditBuyerDescriptorBuilder().withName(VALID_NAME_AMY)
                 .withPhone(VALID_PHONE_BOB).withEmail(VALID_EMAIL_AMY).withHousingType(VALID_HOUSING_TYPE_AMY)
-                .withTags(VALID_TAG_HUSBAND, VALID_TAG_FRIEND).build();
+                .withTags(VALID_TAG_BUYER).build();
         EditBuyerCommand expectedCommand = new EditBuyerCommand(targetIndex, descriptor);
 
         assertParseSuccess(parser, userInput, expectedCommand);
@@ -157,8 +149,8 @@ public class EditBuyerCommandParserTest {
         assertParseSuccess(parser, userInput, expectedCommand);
 
         // tags
-        userInput = targetIndex.getOneBased() + TAG_DESC_FRIEND;
-        descriptor = new EditBuyerDescriptorBuilder().withTags(VALID_TAG_FRIEND).build();
+        userInput = targetIndex.getOneBased() + TAG_DESC_BUYER;
+        descriptor = new EditBuyerDescriptorBuilder().withTags(VALID_TAG_BUYER).build();
         expectedCommand = new EditBuyerCommand(targetIndex, descriptor);
         assertParseSuccess(parser, userInput, expectedCommand);
     }
@@ -181,8 +173,8 @@ public class EditBuyerCommandParserTest {
 
         // mulltiple valid fields repeated
         userInput = targetIndex.getOneBased() + PHONE_DESC_AMY + HOUSING_TYPE_DESC_AMY + EMAIL_DESC_AMY
-                + TAG_DESC_FRIEND + PHONE_DESC_AMY + HOUSING_TYPE_DESC_AMY + EMAIL_DESC_AMY + TAG_DESC_FRIEND
-                + PHONE_DESC_BOB + HOUSING_TYPE_DESC_BOB + EMAIL_DESC_BOB + TAG_DESC_HUSBAND;
+                + VALID_TAG_BUYER + PHONE_DESC_AMY + HOUSING_TYPE_DESC_AMY + EMAIL_DESC_AMY + VALID_TAG_BUYER
+                + PHONE_DESC_BOB + HOUSING_TYPE_DESC_BOB + EMAIL_DESC_BOB + VALID_TAG_BUYER;
 
         assertParseFailure(parser, userInput,
                 Messages.getErrorMessageForDuplicatePrefixes(PREFIX_PHONE, PREFIX_EMAIL, PREFIX_HOUSING_TYPE));

--- a/src/test/java/seedu/address/logic/parser/EditSellerCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/EditSellerCommandParserTest.java
@@ -3,27 +3,19 @@ package seedu.address.logic.parser;
 import static seedu.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 import static seedu.address.logic.commands.CommandTestUtil.EMAIL_DESC_AMY;
 import static seedu.address.logic.commands.CommandTestUtil.EMAIL_DESC_BOB;
-import static seedu.address.logic.commands.CommandTestUtil.HOUSING_TYPE_DESC_AMY;
-import static seedu.address.logic.commands.CommandTestUtil.HOUSING_TYPE_DESC_BOB;
 import static seedu.address.logic.commands.CommandTestUtil.INVALID_EMAIL_DESC;
-import static seedu.address.logic.commands.CommandTestUtil.INVALID_HOUSING_TYPE_DESC;
 import static seedu.address.logic.commands.CommandTestUtil.INVALID_NAME_DESC;
 import static seedu.address.logic.commands.CommandTestUtil.INVALID_PHONE_DESC;
-import static seedu.address.logic.commands.CommandTestUtil.INVALID_TAG_DESC;
 import static seedu.address.logic.commands.CommandTestUtil.NAME_DESC_AMY;
 import static seedu.address.logic.commands.CommandTestUtil.PHONE_DESC_AMY;
 import static seedu.address.logic.commands.CommandTestUtil.PHONE_DESC_BOB;
-import static seedu.address.logic.commands.CommandTestUtil.TAG_DESC_FRIEND;
-import static seedu.address.logic.commands.CommandTestUtil.TAG_DESC_HUSBAND;
+import static seedu.address.logic.commands.CommandTestUtil.TAG_DESC_SELLER;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_EMAIL_AMY;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_HOUSING_TYPE_AMY;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_NAME_AMY;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_PHONE_AMY;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_PHONE_BOB;
-import static seedu.address.logic.commands.CommandTestUtil.VALID_TAG_FRIEND;
-import static seedu.address.logic.commands.CommandTestUtil.VALID_TAG_HUSBAND;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_EMAIL;
-import static seedu.address.logic.parser.CliSyntax.PREFIX_HOUSING_TYPE;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_PHONE;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_TAG;
 import static seedu.address.logic.parser.CommandParserTestUtil.assertParseFailure;
@@ -38,16 +30,12 @@ import seedu.address.commons.core.index.Index;
 import seedu.address.logic.Messages;
 import seedu.address.logic.commands.EditSellerCommand;
 import seedu.address.logic.commands.EditSellerCommand.EditSellerDescriptor;
-import seedu.address.model.house.House;
 import seedu.address.model.person.Email;
 import seedu.address.model.person.Name;
 import seedu.address.model.person.Phone;
-import seedu.address.model.tag.Tag;
 import seedu.address.testutil.EditSellerDescriptorBuilder;
 
 public class EditSellerCommandParserTest {
-
-    private static final String TAG_EMPTY = " " + PREFIX_TAG;
 
     private static final String MESSAGE_INVALID_FORMAT =
             String.format(MESSAGE_INVALID_COMMAND_FORMAT, EditSellerCommand.MESSAGE_USAGE);
@@ -86,17 +74,9 @@ public class EditSellerCommandParserTest {
         assertParseFailure(parser, "1" + INVALID_NAME_DESC, Name.MESSAGE_CONSTRAINTS); // invalid name
         assertParseFailure(parser, "1" + INVALID_PHONE_DESC, Phone.MESSAGE_CONSTRAINTS); // invalid phone
         assertParseFailure(parser, "1" + INVALID_EMAIL_DESC, Email.MESSAGE_CONSTRAINTS); // invalid email
-        assertParseFailure(parser, "1" + INVALID_HOUSING_TYPE_DESC, House.MESSAGE_CONSTRAINTS);
-        assertParseFailure(parser, "1" + INVALID_TAG_DESC, Tag.MESSAGE_CONSTRAINTS); // invalid tag
 
         // invalid phone followed by valid email
         assertParseFailure(parser, "1" + INVALID_PHONE_DESC + EMAIL_DESC_AMY, Phone.MESSAGE_CONSTRAINTS);
-
-        // while parsing {@code PREFIX_TAG} alone will reset the tags of the {@code Person} being edited,
-        // parsing it together with a valid tag results in error
-        assertParseFailure(parser, "1" + TAG_DESC_FRIEND + TAG_DESC_HUSBAND + TAG_EMPTY, Tag.MESSAGE_CONSTRAINTS);
-        assertParseFailure(parser, "1" + TAG_DESC_FRIEND + TAG_EMPTY + TAG_DESC_HUSBAND, Tag.MESSAGE_CONSTRAINTS);
-        assertParseFailure(parser, "1" + TAG_EMPTY + TAG_DESC_FRIEND + TAG_DESC_HUSBAND, Tag.MESSAGE_CONSTRAINTS);
 
         // multiple invalid values, but only the first invalid value is captured
         assertParseFailure(parser, "1" + INVALID_NAME_DESC + INVALID_EMAIL_DESC + VALID_HOUSING_TYPE_AMY
@@ -107,12 +87,11 @@ public class EditSellerCommandParserTest {
     @Test
     public void parse_allFieldsSpecified_success() {
         Index targetIndex = INDEX_SECOND_PERSON;
-        String userInput = targetIndex.getOneBased() + PHONE_DESC_BOB + TAG_DESC_HUSBAND
-                + EMAIL_DESC_AMY + HOUSING_TYPE_DESC_AMY + NAME_DESC_AMY + TAG_DESC_FRIEND;
+        String userInput = targetIndex.getOneBased() + PHONE_DESC_BOB
+                + EMAIL_DESC_AMY + NAME_DESC_AMY;
 
         EditSellerDescriptor descriptor = new EditSellerDescriptorBuilder().withName(VALID_NAME_AMY)
-                .withPhone(VALID_PHONE_BOB).withEmail(VALID_EMAIL_AMY).withHousingType(VALID_HOUSING_TYPE_AMY)
-                .withTags(VALID_TAG_HUSBAND, VALID_TAG_FRIEND).build();
+                .withPhone(VALID_PHONE_BOB).withEmail(VALID_EMAIL_AMY).build();
         EditSellerCommand expectedCommand = new EditSellerCommand(targetIndex, descriptor);
 
         assertParseSuccess(parser, userInput, expectedCommand);
@@ -152,18 +131,6 @@ public class EditSellerCommandParserTest {
         descriptor = new EditSellerDescriptorBuilder().withEmail(VALID_EMAIL_AMY).build();
         expectedCommand = new EditSellerCommand(targetIndex, descriptor);
         assertParseSuccess(parser, userInput, expectedCommand);
-
-        // supposed to be housingtype, commented out
-        //userInput = targetIndex.getOneBased() + HOUSINGTYPE_DESC_AMY;
-        //descriptor = new EditPersonDescriptorBuilder().withHousingType(VALID_HOUSINGTYPE_AMY).build();
-        //expectedCommand = new EditCommand(targetIndex, descriptor);
-        //assertParseSuccess(parser, userInput, expectedCommand);
-
-        // tags
-        userInput = targetIndex.getOneBased() + TAG_DESC_FRIEND;
-        descriptor = new EditSellerDescriptorBuilder().withTags(VALID_TAG_FRIEND).build();
-        expectedCommand = new EditSellerCommand(targetIndex, descriptor);
-        assertParseSuccess(parser, userInput, expectedCommand);
     }
 
     @Test
@@ -183,29 +150,18 @@ public class EditSellerCommandParserTest {
         assertParseFailure(parser, userInput, Messages.getErrorMessageForDuplicatePrefixes(PREFIX_PHONE));
 
         // mulltiple valid fields repeated
-        userInput = targetIndex.getOneBased() + PHONE_DESC_AMY + HOUSING_TYPE_DESC_AMY + EMAIL_DESC_AMY
-                + TAG_DESC_FRIEND + PHONE_DESC_AMY + HOUSING_TYPE_DESC_AMY + EMAIL_DESC_AMY + TAG_DESC_FRIEND
-                + PHONE_DESC_BOB + HOUSING_TYPE_DESC_BOB + EMAIL_DESC_BOB + TAG_DESC_HUSBAND;
+        userInput = targetIndex.getOneBased() + PHONE_DESC_AMY + EMAIL_DESC_AMY
+                + TAG_DESC_SELLER + PHONE_DESC_AMY + EMAIL_DESC_AMY
+                + PHONE_DESC_BOB + EMAIL_DESC_BOB;
 
         assertParseFailure(parser, userInput,
-                Messages.getErrorMessageForDuplicatePrefixes(PREFIX_PHONE, PREFIX_EMAIL, PREFIX_HOUSING_TYPE));
+                Messages.getErrorMessageForDuplicatePrefixes(PREFIX_PHONE, PREFIX_EMAIL));
 
         // multiple invalid values
-        userInput = targetIndex.getOneBased() + INVALID_PHONE_DESC + INVALID_HOUSING_TYPE_DESC + INVALID_EMAIL_DESC
-                + INVALID_PHONE_DESC + INVALID_HOUSING_TYPE_DESC + INVALID_EMAIL_DESC;
+        userInput = targetIndex.getOneBased() + INVALID_PHONE_DESC + INVALID_EMAIL_DESC
+                + INVALID_PHONE_DESC + INVALID_EMAIL_DESC;
 
         assertParseFailure(parser, userInput,
-                Messages.getErrorMessageForDuplicatePrefixes(PREFIX_PHONE, PREFIX_EMAIL, PREFIX_HOUSING_TYPE));
-    }
-
-    @Test
-    public void parse_resetTags_success() {
-        Index targetIndex = INDEX_THIRD_PERSON;
-        String userInput = targetIndex.getOneBased() + TAG_EMPTY;
-
-        EditSellerDescriptor descriptor = new EditSellerDescriptorBuilder().withTags().build();
-        EditSellerCommand expectedCommand = new EditSellerCommand(targetIndex, descriptor);
-
-        assertParseSuccess(parser, userInput, expectedCommand);
+                Messages.getErrorMessageForDuplicatePrefixes(PREFIX_PHONE, PREFIX_EMAIL));
     }
 }

--- a/src/test/java/seedu/address/logic/parser/EditSellerCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/EditSellerCommandParserTest.java
@@ -17,7 +17,6 @@ import static seedu.address.logic.commands.CommandTestUtil.VALID_PHONE_AMY;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_PHONE_BOB;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_EMAIL;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_PHONE;
-import static seedu.address.logic.parser.CliSyntax.PREFIX_TAG;
 import static seedu.address.logic.parser.CommandParserTestUtil.assertParseFailure;
 import static seedu.address.logic.parser.CommandParserTestUtil.assertParseSuccess;
 import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST_PERSON;

--- a/src/test/java/seedu/address/model/AddressBookTest.java
+++ b/src/test/java/seedu/address/model/AddressBookTest.java
@@ -3,7 +3,7 @@ package seedu.address.model;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
-import static seedu.address.logic.commands.CommandTestUtil.VALID_TAG_HUSBAND;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_TAG_SELLER;
 import static seedu.address.testutil.Assert.assertThrows;
 import static seedu.address.testutil.TypicalPersons.ALICE_SELLER;
 import static seedu.address.testutil.TypicalPersons.getTypicalAddressBook;
@@ -47,7 +47,7 @@ public class AddressBookTest {
         // TODO: add buyer
         // Two persons with the same identity fields
         Person editedAlice = new SellerBuilder(ALICE_SELLER)
-                .withTags(VALID_TAG_HUSBAND)
+                .withTags(VALID_TAG_SELLER)
                 .build();
         List<Person> newPersons = Arrays.asList(ALICE_SELLER, editedAlice);
         AddressBookStub newData = new AddressBookStub(newPersons);
@@ -76,7 +76,7 @@ public class AddressBookTest {
         // TODO: add buyer
         addressBook.addPerson(ALICE_SELLER);
         Person editedAlice = new SellerBuilder(ALICE_SELLER)
-                .withTags(VALID_TAG_HUSBAND)
+                .withTags(VALID_TAG_SELLER)
                 .build();
         assertTrue(addressBook.hasPerson(editedAlice));
     }

--- a/src/test/java/seedu/address/model/person/BuyerTest.java
+++ b/src/test/java/seedu/address/model/person/BuyerTest.java
@@ -9,8 +9,6 @@ import static seedu.address.logic.commands.CommandTestUtil.VALID_HOUSING_TYPE_BO
 import static seedu.address.logic.commands.CommandTestUtil.VALID_NAME_BEN;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_NAME_BOB;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_PHONE_BOB;
-import static seedu.address.logic.commands.CommandTestUtil.VALID_TAG_BUYER;
-import static seedu.address.logic.commands.CommandTestUtil.VALID_TAG_SELLER;
 import static seedu.address.testutil.TypicalPersons.ALI_BUYER;
 import static seedu.address.testutil.TypicalPersons.BEN_BUYER;
 import static seedu.address.testutil.TypicalPersons.BOB;
@@ -37,7 +35,7 @@ public class BuyerTest {
 
         // same name, all other attributes different -> returns true
         Person editedAli = new BuyerBuilder(ALI_BUYER).withPhone(VALID_PHONE_BOB).withEmail(VALID_EMAIL_BOB)
-                .withHousingType(VALID_HOUSING_TYPE_BOB).withTags(VALID_TAG_BUYER).build();
+                .withHousingType(VALID_HOUSING_TYPE_BOB).build();
         assertTrue(ALI_BUYER.isSamePerson(editedAli));
 
         // different name, all other attributes same -> returns false
@@ -88,10 +86,6 @@ public class BuyerTest {
 
         // different housingtype -> returns false
         editedAli = new BuyerBuilder(ALI_BUYER).withHousingType(VALID_HOUSING_TYPE_BOB).build();
-        assertFalse(ALI_BUYER.equals(editedAli));
-
-        // different tags -> returns false
-        editedAli = new BuyerBuilder(ALI_BUYER).withTags(VALID_TAG_SELLER).build();
         assertFalse(ALI_BUYER.equals(editedAli));
     }
 

--- a/src/test/java/seedu/address/model/person/BuyerTest.java
+++ b/src/test/java/seedu/address/model/person/BuyerTest.java
@@ -9,7 +9,8 @@ import static seedu.address.logic.commands.CommandTestUtil.VALID_HOUSING_TYPE_BO
 import static seedu.address.logic.commands.CommandTestUtil.VALID_NAME_BEN;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_NAME_BOB;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_PHONE_BOB;
-import static seedu.address.logic.commands.CommandTestUtil.VALID_TAG_HUSBAND;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_TAG_BUYER;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_TAG_SELLER;
 import static seedu.address.testutil.TypicalPersons.ALI_BUYER;
 import static seedu.address.testutil.TypicalPersons.BEN_BUYER;
 import static seedu.address.testutil.TypicalPersons.BOB;
@@ -36,7 +37,7 @@ public class BuyerTest {
 
         // same name, all other attributes different -> returns true
         Person editedAli = new BuyerBuilder(ALI_BUYER).withPhone(VALID_PHONE_BOB).withEmail(VALID_EMAIL_BOB)
-                .withHousingType(VALID_HOUSING_TYPE_BOB).withTags(VALID_TAG_HUSBAND).build();
+                .withHousingType(VALID_HOUSING_TYPE_BOB).withTags(VALID_TAG_BUYER).build();
         assertTrue(ALI_BUYER.isSamePerson(editedAli));
 
         // different name, all other attributes same -> returns false
@@ -90,7 +91,7 @@ public class BuyerTest {
         assertFalse(ALI_BUYER.equals(editedAli));
 
         // different tags -> returns false
-        editedAli = new BuyerBuilder(ALI_BUYER).withTags(VALID_TAG_HUSBAND).build();
+        editedAli = new BuyerBuilder(ALI_BUYER).withTags(VALID_TAG_SELLER).build();
         assertFalse(ALI_BUYER.equals(editedAli));
     }
 

--- a/src/test/java/seedu/address/model/person/PersonTest.java
+++ b/src/test/java/seedu/address/model/person/PersonTest.java
@@ -8,7 +8,6 @@ import static seedu.address.logic.commands.CommandTestUtil.VALID_HOUSING_TYPE_BO
 import static seedu.address.logic.commands.CommandTestUtil.VALID_NAME_BOB;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_PHONE_BOB;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_TAG_BUYER;
-import static seedu.address.logic.commands.CommandTestUtil.VALID_TAG_SELLER;
 import static seedu.address.testutil.Assert.assertThrows;
 import static seedu.address.testutil.TypicalPersons.ALICE;
 import static seedu.address.testutil.TypicalPersons.BOB;
@@ -80,10 +79,6 @@ public class PersonTest {
 
         // different email -> returns false
         editedAlice = new PersonBuilder(ALICE).withEmail(VALID_EMAIL_BOB).build();
-        assertFalse(ALICE.equals(editedAlice));
-
-        // different tags -> returns false
-        editedAlice = new PersonBuilder(ALICE).withTags(VALID_TAG_SELLER).build();
         assertFalse(ALICE.equals(editedAlice));
     }
 

--- a/src/test/java/seedu/address/model/person/PersonTest.java
+++ b/src/test/java/seedu/address/model/person/PersonTest.java
@@ -7,7 +7,8 @@ import static seedu.address.logic.commands.CommandTestUtil.VALID_EMAIL_BOB;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_HOUSING_TYPE_BOB;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_NAME_BOB;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_PHONE_BOB;
-import static seedu.address.logic.commands.CommandTestUtil.VALID_TAG_HUSBAND;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_TAG_BUYER;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_TAG_SELLER;
 import static seedu.address.testutil.Assert.assertThrows;
 import static seedu.address.testutil.TypicalPersons.ALICE;
 import static seedu.address.testutil.TypicalPersons.BOB;
@@ -34,7 +35,7 @@ public class PersonTest {
 
         // same name, all other attributes different -> returns true
         Person editedAlice = new PersonBuilder(ALICE).withPhone(VALID_PHONE_BOB).withEmail(VALID_EMAIL_BOB)
-                .withHousingType(VALID_HOUSING_TYPE_BOB).withTags(VALID_TAG_HUSBAND).build();
+                .withHousingType(VALID_HOUSING_TYPE_BOB).withTags(VALID_TAG_BUYER).build();
         assertTrue(ALICE.isSamePerson(editedAlice));
 
         // different name, all other attributes same -> returns false
@@ -82,7 +83,7 @@ public class PersonTest {
         assertFalse(ALICE.equals(editedAlice));
 
         // different tags -> returns false
-        editedAlice = new PersonBuilder(ALICE).withTags(VALID_TAG_HUSBAND).build();
+        editedAlice = new PersonBuilder(ALICE).withTags(VALID_TAG_SELLER).build();
         assertFalse(ALICE.equals(editedAlice));
     }
 

--- a/src/test/java/seedu/address/model/person/SellerTest.java
+++ b/src/test/java/seedu/address/model/person/SellerTest.java
@@ -66,9 +66,9 @@ public class SellerTest {
 
         // Create new Seller instances with houses
         Seller sellerAlice = new Seller(ALICE_SELLER.getName(), ALICE_SELLER.getPhone(), ALICE_SELLER.getEmail(),
-                aliceHouses, ALICE_SELLER.getTags());
+                aliceHouses);
         Seller sellerBob = new Seller(BOB_SELLER.getName(), BOB_SELLER.getPhone(), BOB_SELLER.getEmail(),
-                bobHouses, BOB_SELLER.getTags());
+                bobHouses);
 
         // same object -> returns true
         assertTrue(sellerAlice.equals(sellerAlice));
@@ -84,13 +84,13 @@ public class SellerTest {
 
         // Same details, different houses -> returns false
         Seller sellerAliceCloneWithDifferentHouses = new Seller(ALICE_SELLER.getName(), ALICE_SELLER.getPhone(),
-                ALICE_SELLER.getEmail(), bobHouses, ALICE_SELLER.getTags());
+                ALICE_SELLER.getEmail(), bobHouses);
         assertFalse(sellerAlice.getHouses().get(0).toString()
                 .equals(sellerAliceCloneWithDifferentHouses.getHouses().get(0).toString()));
 
         // Same details, same houses -> returns true
         Seller sellerAliceClone = new Seller(ALICE_SELLER.getName(), ALICE_SELLER.getPhone(), ALICE_SELLER.getEmail(),
-                aliceHouses, ALICE_SELLER.getTags());
+                aliceHouses);
         assertTrue(sellerAlice.getHouses().get(0).toString().equals(sellerAliceClone.getHouses().get(0).toString()));
     }
 

--- a/src/test/java/seedu/address/model/person/SellerTest.java
+++ b/src/test/java/seedu/address/model/person/SellerTest.java
@@ -7,7 +7,7 @@ import static seedu.address.logic.commands.CommandTestUtil.VALID_EMAIL_BOB;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_NAME_BOB;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_NAME_KHOONSUN;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_PHONE_BOB;
-import static seedu.address.logic.commands.CommandTestUtil.VALID_TAG_HUSBAND;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_TAG_SELLER;
 import static seedu.address.testutil.Assert.assertThrows;
 import static seedu.address.testutil.TypicalHouses.HOUSE2;
 import static seedu.address.testutil.TypicalHouses.HOUSE3;
@@ -40,7 +40,7 @@ public class SellerTest {
 
         // same name, all other attributes different -> returns true
         Person editedAlice = new SellerBuilder(ALICE_SELLER).withPhone(VALID_PHONE_BOB).withEmail(VALID_EMAIL_BOB)
-                .withTags(VALID_TAG_HUSBAND).build();
+                .withTags(VALID_TAG_SELLER).build();
         assertTrue(ALICE_SELLER.isSamePerson(editedAlice));
 
         // different name, all other attributes same -> returns false

--- a/src/test/java/seedu/address/model/person/UniquePersonListTest.java
+++ b/src/test/java/seedu/address/model/person/UniquePersonListTest.java
@@ -3,7 +3,7 @@ package seedu.address.model.person;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
-import static seedu.address.logic.commands.CommandTestUtil.VALID_TAG_HUSBAND;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_TAG_SELLER;
 import static seedu.address.testutil.Assert.assertThrows;
 import static seedu.address.testutil.TypicalPersons.ALICE_SELLER;
 import static seedu.address.testutil.TypicalPersons.BOB_SELLER;
@@ -42,7 +42,7 @@ public class UniquePersonListTest {
     public void contains_personWithSameIdentityFieldsInList_returnsTrue() {
         // TODO: For v1.3, add in Buyer
         uniquePersonList.add(ALICE_SELLER);
-        Person editedAlice = new SellerBuilder(ALICE_SELLER).withTags(VALID_TAG_HUSBAND)
+        Person editedAlice = new SellerBuilder(ALICE_SELLER).withTags(VALID_TAG_SELLER)
                 .build();
         assertTrue(uniquePersonList.contains(editedAlice));
     }
@@ -86,7 +86,7 @@ public class UniquePersonListTest {
     public void setPerson_editedPersonHasSameIdentity_success() {
         // TODO: do for buyer as well
         uniquePersonList.add(ALICE_SELLER);
-        Person editedAlice = new SellerBuilder(ALICE_SELLER).withTags(VALID_TAG_HUSBAND)
+        Person editedAlice = new SellerBuilder(ALICE_SELLER).withTags(VALID_TAG_SELLER)
                 .build();
         uniquePersonList.setPerson(ALICE_SELLER, editedAlice);
         UniquePersonList expectedUniquePersonList = new UniquePersonList();

--- a/src/test/java/seedu/address/testutil/BuyerBuilder.java
+++ b/src/test/java/seedu/address/testutil/BuyerBuilder.java
@@ -1,16 +1,11 @@
 package seedu.address.testutil;
 
-import java.util.HashSet;
-import java.util.Set;
-
 import seedu.address.model.house.HousingType;
 import seedu.address.model.person.Budget;
 import seedu.address.model.person.Buyer;
 import seedu.address.model.person.Email;
 import seedu.address.model.person.Name;
 import seedu.address.model.person.Phone;
-import seedu.address.model.tag.Tag;
-import seedu.address.model.util.SampleDataUtil;
 
 
 /**
@@ -22,14 +17,12 @@ public class BuyerBuilder {
     public static final String DEFAULT_EMAIL = "james@gmail.com";
     public static final String DEFAULT_BUDGET = "666000";
     public static final String DEFAULT_HOUSING_TYPE = "Hdb";
-    public static final String DEFAULT_BUYER_TAG = "Buyer";
 
     private Name name;
     private Phone phone;
     private Email email;
     private HousingType preferredHousingType;
     private Budget budget;
-    private Set<Tag> tags;
 
     /**
      * Creates a {@code BuyerBuilder} with the default information.
@@ -40,8 +33,6 @@ public class BuyerBuilder {
         email = new Email(DEFAULT_EMAIL);
         preferredHousingType = new HousingType(DEFAULT_HOUSING_TYPE);
         budget = new Budget(DEFAULT_BUDGET);
-        tags = new HashSet<>();
-        tags.add(new Tag(DEFAULT_BUYER_TAG));
     }
 
     /**
@@ -53,7 +44,6 @@ public class BuyerBuilder {
         email = personToCopy.getEmail();
         preferredHousingType = personToCopy.getPreferredHousingType();
         budget = personToCopy.getBudget();
-        tags = new HashSet<>(personToCopy.getTags());
     }
 
     /**
@@ -96,15 +86,7 @@ public class BuyerBuilder {
         return this;
     }
 
-    /**
-     * Parses the {@code tags} into a {@code Set<Tag>} and set it to the {@code Person} that we are building.
-     */
-    public BuyerBuilder withTags(String ... tags) {
-        this.tags = SampleDataUtil.getTagSet(tags);
-        return this;
-    }
-
     public Buyer build() {
-        return new Buyer(name, phone, email, budget, preferredHousingType, tags);
+        return new Buyer(name, phone, email, budget, preferredHousingType);
     }
 }

--- a/src/test/java/seedu/address/testutil/BuyerBuilder.java
+++ b/src/test/java/seedu/address/testutil/BuyerBuilder.java
@@ -22,6 +22,7 @@ public class BuyerBuilder {
     public static final String DEFAULT_EMAIL = "james@gmail.com";
     public static final String DEFAULT_BUDGET = "666000";
     public static final String DEFAULT_HOUSING_TYPE = "Hdb";
+    public static final String DEFAULT_BUYER_TAG = "Buyer";
 
     private Name name;
     private Phone phone;
@@ -40,6 +41,7 @@ public class BuyerBuilder {
         preferredHousingType = new HousingType(DEFAULT_HOUSING_TYPE);
         budget = new Budget(DEFAULT_BUDGET);
         tags = new HashSet<>();
+        tags.add(new Tag(DEFAULT_BUYER_TAG));
     }
 
     /**

--- a/src/test/java/seedu/address/testutil/EditBuyerDescriptorBuilder.java
+++ b/src/test/java/seedu/address/testutil/EditBuyerDescriptorBuilder.java
@@ -37,7 +37,6 @@ public class EditBuyerDescriptorBuilder {
         this.descriptor.setEmail(buyer.getEmail());
         this.descriptor.setHousingType(buyer.getPreferredHousingType());
         this.descriptor.setBudget(buyer.getBudget());
-        this.descriptor.setTags(buyer.getTags());
     }
 
     /**

--- a/src/test/java/seedu/address/testutil/EditSellerDescriptorBuilder.java
+++ b/src/test/java/seedu/address/testutil/EditSellerDescriptorBuilder.java
@@ -5,7 +5,6 @@ import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import seedu.address.logic.commands.EditSellerCommand.EditSellerDescriptor;
-import seedu.address.model.house.HousingType;
 import seedu.address.model.person.Email;
 import seedu.address.model.person.Name;
 import seedu.address.model.person.Person;
@@ -35,7 +34,6 @@ public class EditSellerDescriptorBuilder {
         descriptor.setName(person.getName());
         descriptor.setPhone(person.getPhone());
         descriptor.setEmail(person.getEmail());
-        descriptor.setTags(person.getTags());
     }
 
     /**
@@ -59,14 +57,6 @@ public class EditSellerDescriptorBuilder {
      */
     public EditSellerDescriptorBuilder withEmail(String email) {
         descriptor.setEmail(new Email(email));
-        return this;
-    }
-
-    /**
-     * Sets the Housing Type of the {@code EditPersonDescriptor} that we are building.
-     */
-    public EditSellerDescriptorBuilder withHousingType(String housingType) {
-        descriptor.setHousingType(new HousingType(housingType));
         return this;
     }
 

--- a/src/test/java/seedu/address/testutil/PersonBuilder.java
+++ b/src/test/java/seedu/address/testutil/PersonBuilder.java
@@ -85,6 +85,6 @@ public class PersonBuilder {
     }
 
     public Person build() {
-        return new Person(name, phone, email, tags);
+        return new Person(name, phone, email);
     }
 }

--- a/src/test/java/seedu/address/testutil/PersonUtil.java
+++ b/src/test/java/seedu/address/testutil/PersonUtil.java
@@ -116,12 +116,11 @@ public class PersonUtil {
     /**
      * Returns the part of command string for the given {@code EditPersonDescriptor}'s details.
      */
-    public static String getEditPersonDescriptorDetails(EditSellerDescriptor descriptor) {
+    public static String getEditSellerDescriptorDetails(EditSellerDescriptor descriptor) {
         StringBuilder sb = new StringBuilder();
         descriptor.getName().ifPresent(name -> sb.append(PREFIX_NAME).append(name.fullName).append(" "));
         descriptor.getPhone().ifPresent(phone -> sb.append(PREFIX_PHONE).append(phone.value).append(" "));
         descriptor.getEmail().ifPresent(email -> sb.append(PREFIX_EMAIL).append(email.value).append(" "));
-        descriptor.getHousingType().ifPresent(housingType -> sb.append(PREFIX_HOUSING_TYPE).append(" "));
         if (descriptor.getTags().isPresent()) {
             Set<Tag> tags = descriptor.getTags().get();
             if (tags.isEmpty()) {

--- a/src/test/java/seedu/address/testutil/PersonUtil.java
+++ b/src/test/java/seedu/address/testutil/PersonUtil.java
@@ -69,9 +69,6 @@ public class PersonUtil {
         sb.append(PREFIX_EMAIL + buyer.getEmail().value + " ");
         sb.append(PREFIX_HOUSING_TYPE + buyer.getPreferredHousingType().value + " ");
         sb.append(PREFIX_BUDGET + buyer.getBudget().value + " ");
-        buyer.getTags().stream().forEach(
-                s -> sb.append(PREFIX_TAG + s.tagName + " ")
-        );
         return sb.toString();
     }
 

--- a/src/test/java/seedu/address/testutil/SellerBuilder.java
+++ b/src/test/java/seedu/address/testutil/SellerBuilder.java
@@ -20,7 +20,8 @@ public class SellerBuilder {
 
     public static final String DEFAULT_NAME = "Amy Bee";
     public static final String DEFAULT_PHONE = "85355255";
-    public static final String DEFAULT_EMAIL = "amy@gmail.com";
+    public static final String DEFAULT_EMAIL = "amy@gmaidasdasl.com";
+    public static final String DEFAULT_SELLER_TAG = "Seller";
 
     private Name name;
     private Phone phone;
@@ -37,6 +38,7 @@ public class SellerBuilder {
         email = new Email(DEFAULT_EMAIL);
         houses = new ArrayList<>();
         tags = new HashSet<>();
+        tags.add(new Tag(DEFAULT_SELLER_TAG));
     }
 
     /**

--- a/src/test/java/seedu/address/testutil/SellerBuilder.java
+++ b/src/test/java/seedu/address/testutil/SellerBuilder.java
@@ -93,6 +93,6 @@ public class SellerBuilder {
     }
 
     public Seller build() {
-        return new Seller(name, phone, email, houses, tags);
+        return new Seller(name, phone, email, houses);
     }
 }

--- a/src/test/java/seedu/address/testutil/TypicalPersons.java
+++ b/src/test/java/seedu/address/testutil/TypicalPersons.java
@@ -18,8 +18,8 @@ import static seedu.address.logic.commands.CommandTestUtil.VALID_PHONE_AMY;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_PHONE_BEN;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_PHONE_BOB;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_PHONE_KHOONSUN;
-import static seedu.address.logic.commands.CommandTestUtil.VALID_TAG_FRIEND;
-import static seedu.address.logic.commands.CommandTestUtil.VALID_TAG_HUSBAND;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_TAG_BUYER;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_TAG_SELLER;
 import static seedu.address.testutil.TypicalHouses.HOUSE1;
 import static seedu.address.testutil.TypicalHouses.HOUSE2;
 import static seedu.address.testutil.TypicalHouses.HOUSE3;
@@ -53,100 +53,102 @@ public class TypicalPersons {
             .withPhone("94351253").withHouses(new Hdb(new Level("15"),
                     new PostalCode("654321"), new Street("Orchard Street"), new UnitNumber("150"), new Block("10A"),
                     new Price("123456")))
-            .withTags("friends").build();
+            .withTags("Seller").build();
     public static final Seller BENSON_SELLER = new SellerBuilder().withName("Benson Meier")
             .withEmail("johnd@example.com")
             .withPhone("94351253").withHouses(new Hdb(new Level("16"), new PostalCode("654321"),
                     new Street("Orchard Street"), new UnitNumber("150"), new Block("9A"), new Price("789101112")))
-            .withTags("friends").build();
+            .withTags("Seller").build();
     public static final Seller CARL_SELLER = new SellerBuilder().withName("Carl Kurz").withPhone("95352563")
             .withEmail("heinz@example.com").withHouses(new Hdb(new Level("17"),
                     new PostalCode("654322"), new Street("Orchard Street 1"), new UnitNumber("150"), new Block("10B"),
                     new Price("43146141")))
-            .build();
+            .withTags("Seller").build();
     public static final Seller DANIEL_SELLER = new SellerBuilder().withName("Daniel Meier").withPhone("87652533")
             .withEmail("cornelia@example.com").withHouses(new Hdb(new Level("18"),
                     new PostalCode("654323"), new Street("Orchard Street 2"),
-                    new UnitNumber("150"), new Block("10C"), new Price("3123123"))).withTags("friends").build();
+                    new UnitNumber("150"), new Block("10C"), new Price("3123123"))).withTags("Seller").build();
     public static final Seller ELLE_SELLER = new SellerBuilder().withName("Elle Meyer").withPhone("9482224")
             .withEmail("heinz@example.com").withHouses(new Hdb(new Level("19"), new PostalCode("654324"),
                     new Street("Orchard Street 3"), new UnitNumber("150"), new Block("10D"),
-                    new Price("3453465"))).build();
+                    new Price("3453465")))
+            .withTags("Seller").build();
     public static final Seller FIONA_SELLER = new SellerBuilder().withName("Fiona Kunz").withPhone("9482427")
             .withEmail("heinz@example.com").withHouses(new Hdb(new Level("20"), new PostalCode("654325"),
                     new Street("Orchard Street 4"), new UnitNumber("150"), new Block("10E"),
-                    new Price("55555555"))).build();
+                    new Price("55555555")))
+            .withTags("Seller").build();
     public static final Seller GEORGE_SELLER = new SellerBuilder().withName("George Best").withPhone("9482442")
             .withEmail("heinz@example.com").withHouses(new Landed(new UnitNumber("150"), new PostalCode("654326"),
-                    new Street("Orchard Street 5"), new Price("8945939"))).build();
+                    new Street("Orchard Street 5"), new Price("8945939")))
+            .withTags("Seller").build();
     public static final Buyer ALICE_BUYER = new BuyerBuilder().withName("George Best").withPhone("9482442")
-            .withEmail("heinz@example.com").withBudget("333000").withHousingType("Hdb").build();
+            .withEmail("heinz@example.com").withBudget("333000").withHousingType("Hdb").withTags("Buyer").build();
 
     // Manually added
     public static final Seller HOON_SELLER = new SellerBuilder().withName("Hoon Meier").withPhone("8482424")
             .withEmail("stefan@example.com").withEmail("heinz@example.com").withHouses(new Hdb(new Level("22"),
                     new PostalCode("654327"), new Street("Orchard Street 6"),
-                    new UnitNumber("150"), new Block("3"), new Price("7777777"))).build();
+                    new UnitNumber("150"), new Block("3"), new Price("7777777"))).withTags("Seller").build();
     public static final Seller IDA_SELLER = new SellerBuilder().withName("Ida Mueller").withPhone("8482131")
             .withEmail("hans@example.com").withEmail("heinz@example.com").withHouses(new Hdb(new Level("23"),
                     new PostalCode("654328"), new Street("Orchard Street 7"), new UnitNumber("150"),
-                    new Block("4"), new Price("9876372"))).build();
+                    new Block("4"), new Price("9876372"))).withTags("Seller").build();
 
     // Manually added - Seller's details found in {@code CommandTestUtil}
     public static final Seller AMY_SELLER = new SellerBuilder().withName(VALID_NAME_AMY)
             .withEmail(VALID_EMAIL_AMY)
             .withPhone(VALID_PHONE_AMY)
-            .withTags(VALID_TAG_FRIEND).withHouses(HOUSE2).build();
+            .withTags(VALID_TAG_SELLER).withHouses(HOUSE2).build();
 
     public static final Seller KHOONSUN_SELLER = new SellerBuilder().withName(VALID_NAME_KHOONSUN)
             .withEmail(VALID_EMAIL_KHOONSUN)
             .withPhone(VALID_PHONE_KHOONSUN)
-            .withTags(VALID_TAG_FRIEND).withHouses(HOUSE1).build();
-
+            .withTags(VALID_TAG_SELLER).withHouses(HOUSE1).build();
     public static final Seller BOB_SELLER = new SellerBuilder().withName(VALID_NAME_BOB)
             .withEmail(VALID_EMAIL_BOB)
             .withPhone(VALID_PHONE_BOB)
-            .withTags(VALID_TAG_HUSBAND, VALID_TAG_FRIEND).withHouses(HOUSE3).build();
+            .withTags(VALID_TAG_SELLER).withHouses(HOUSE3).build();
 
     // Manually added - Buyer's details found in {@code CommandTestUtil}
     public static final Buyer ALI_BUYER = new BuyerBuilder().withName("Ali York")
             .withPhone("82937163").withEmail("ali@gmail.com").withBudget("400000")
-            .withHousingType("Hdb").withTags("friends").build();
+            .withHousingType("Hdb").withTags("Buyer").build();
     public static final Buyer BEN_BUYER = new BuyerBuilder().withName(VALID_NAME_BEN).withPhone(VALID_PHONE_BEN)
             .withEmail(VALID_EMAIL_BEN).withBudget(VALID_BUDGET_BEN).withHousingType(VALID_HOUSING_TYPE_BEN)
-            .withTags(VALID_TAG_HUSBAND, VALID_TAG_FRIEND)
+            .withTags("Buyer")
             .build();
 
     public static final Buyer AMY_BUYER = new BuyerBuilder().withName(VALID_NAME_AMY).withPhone(VALID_PHONE_AMY)
             .withEmail(VALID_EMAIL_AMY).withBudget(VALID_BUDGET_AMY).withHousingType(VALID_HOUSING_TYPE_AMY)
-            .withTags(VALID_TAG_HUSBAND, VALID_TAG_FRIEND)
+            .withTags("Buyer")
             .build();
 
     public static final Buyer BOB_BUYER = new BuyerBuilder().withName(VALID_NAME_BOB).withPhone(VALID_PHONE_BOB)
             .withEmail(VALID_EMAIL_BOB).withBudget(VALID_BUDGET_BOB).withHousingType(VALID_HOUSING_TYPE_BOB)
-            .withTags(VALID_TAG_HUSBAND, VALID_TAG_FRIEND)
+            .withTags("Buyer")
             .build();
     public static final Buyer ZACK_BUYER = new BuyerBuilder().withName("Zack York")
             .withPhone("82937163").withEmail("zack@gmail.com").withBudget("400000")
-            .withHousingType("Hdb").withTags("friends").build();
+            .withHousingType("Hdb").withTags("Buyer").build();
     public static final Buyer ZANE_BUYER = new BuyerBuilder().withName("Zane York")
             .withPhone("82937163").withEmail("zack@gmail.com").withBudget("500000")
-            .withHousingType("Hdb").withTags("friends").build();
+            .withHousingType("Hdb").withTags("Buyer").build();
     public static final Buyer ZURI_BUYER = new BuyerBuilder().withName("Zuri")
             .withPhone("63936234").withEmail("Zuri@gmail.com").withBudget("600000")
-            .withHousingType("Hdb").withTags("someone").build();
+            .withHousingType("Hdb").withTags("Buyer").build();
     public static final Buyer ZYRA_BUYER = new BuyerBuilder().withName("Zyra Moore")
             .withPhone("82936234").withEmail("zyra@gmail.com").withBudget("700000")
-            .withHousingType("Hdb").withTags("someone").build();
+            .withHousingType("Hdb").withTags("Buyer").build();
 
     // Manually added - Person's details found in {@code CommandTestUtil}
     public static final Person ALICE = new PersonBuilder().withName("Alice Pauline")
             .withEmail("alice@example.com")
             .withPhone("94351253").withHousingType("Hdb")
-            .withTags("friends").build();
+            .withTags("Buyer").build();
     public static final Person BOB = new PersonBuilder().withName(VALID_NAME_BOB).withPhone(VALID_PHONE_BOB)
             .withEmail(VALID_EMAIL_BOB).withHousingType(VALID_HOUSING_TYPE_BOB)
-            .withTags(VALID_TAG_HUSBAND, VALID_TAG_FRIEND)
+            .withTags(VALID_TAG_BUYER)
             .build();
 
     public static final String KEYWORD_MATCHING_MEIER = "Meier"; // A keyword that matches MEIER

--- a/src/test/java/seedu/address/testutil/TypicalPersons.java
+++ b/src/test/java/seedu/address/testutil/TypicalPersons.java
@@ -18,8 +18,6 @@ import static seedu.address.logic.commands.CommandTestUtil.VALID_PHONE_AMY;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_PHONE_BEN;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_PHONE_BOB;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_PHONE_KHOONSUN;
-import static seedu.address.logic.commands.CommandTestUtil.VALID_TAG_BUYER;
-import static seedu.address.logic.commands.CommandTestUtil.VALID_TAG_SELLER;
 import static seedu.address.testutil.TypicalHouses.HOUSE1;
 import static seedu.address.testutil.TypicalHouses.HOUSE2;
 import static seedu.address.testutil.TypicalHouses.HOUSE3;
@@ -53,102 +51,110 @@ public class TypicalPersons {
             .withPhone("94351253").withHouses(new Hdb(new Level("15"),
                     new PostalCode("654321"), new Street("Orchard Street"), new UnitNumber("150"), new Block("10A"),
                     new Price("123456")))
-            .withTags("Seller").build();
+            .build();
     public static final Seller BENSON_SELLER = new SellerBuilder().withName("Benson Meier")
             .withEmail("johnd@example.com")
             .withPhone("94351253").withHouses(new Hdb(new Level("16"), new PostalCode("654321"),
                     new Street("Orchard Street"), new UnitNumber("150"), new Block("9A"), new Price("789101112")))
-            .withTags("Seller").build();
+            .build();
     public static final Seller CARL_SELLER = new SellerBuilder().withName("Carl Kurz").withPhone("95352563")
             .withEmail("heinz@example.com").withHouses(new Hdb(new Level("17"),
                     new PostalCode("654322"), new Street("Orchard Street 1"), new UnitNumber("150"), new Block("10B"),
                     new Price("43146141")))
-            .withTags("Seller").build();
+            .build();
     public static final Seller DANIEL_SELLER = new SellerBuilder().withName("Daniel Meier").withPhone("87652533")
             .withEmail("cornelia@example.com").withHouses(new Hdb(new Level("18"),
                     new PostalCode("654323"), new Street("Orchard Street 2"),
-                    new UnitNumber("150"), new Block("10C"), new Price("3123123"))).withTags("Seller").build();
+                    new UnitNumber("150"), new Block("10C"), new Price("3123123")))
+            .build();
     public static final Seller ELLE_SELLER = new SellerBuilder().withName("Elle Meyer").withPhone("9482224")
             .withEmail("heinz@example.com").withHouses(new Hdb(new Level("19"), new PostalCode("654324"),
                     new Street("Orchard Street 3"), new UnitNumber("150"), new Block("10D"),
                     new Price("3453465")))
-            .withTags("Seller").build();
+            .build();
     public static final Seller FIONA_SELLER = new SellerBuilder().withName("Fiona Kunz").withPhone("9482427")
             .withEmail("heinz@example.com").withHouses(new Hdb(new Level("20"), new PostalCode("654325"),
                     new Street("Orchard Street 4"), new UnitNumber("150"), new Block("10E"),
                     new Price("55555555")))
-            .withTags("Seller").build();
+            .build();
     public static final Seller GEORGE_SELLER = new SellerBuilder().withName("George Best").withPhone("9482442")
             .withEmail("heinz@example.com").withHouses(new Landed(new UnitNumber("150"), new PostalCode("654326"),
                     new Street("Orchard Street 5"), new Price("8945939")))
-            .withTags("Seller").build();
+            .build();
     public static final Buyer ALICE_BUYER = new BuyerBuilder().withName("George Best").withPhone("9482442")
-            .withEmail("heinz@example.com").withBudget("333000").withHousingType("Hdb").withTags("Buyer").build();
+            .withEmail("heinz@example.com").withBudget("333000").withHousingType("Hdb")
+            .build();
 
     // Manually added
     public static final Seller HOON_SELLER = new SellerBuilder().withName("Hoon Meier").withPhone("8482424")
             .withEmail("stefan@example.com").withEmail("heinz@example.com").withHouses(new Hdb(new Level("22"),
                     new PostalCode("654327"), new Street("Orchard Street 6"),
-                    new UnitNumber("150"), new Block("3"), new Price("7777777"))).withTags("Seller").build();
+                    new UnitNumber("150"), new Block("3"), new Price("7777777")))
+            .build();
     public static final Seller IDA_SELLER = new SellerBuilder().withName("Ida Mueller").withPhone("8482131")
             .withEmail("hans@example.com").withEmail("heinz@example.com").withHouses(new Hdb(new Level("23"),
                     new PostalCode("654328"), new Street("Orchard Street 7"), new UnitNumber("150"),
-                    new Block("4"), new Price("9876372"))).withTags("Seller").build();
+                    new Block("4"), new Price("9876372")))
+            .build();
 
     // Manually added - Seller's details found in {@code CommandTestUtil}
     public static final Seller AMY_SELLER = new SellerBuilder().withName(VALID_NAME_AMY)
             .withEmail(VALID_EMAIL_AMY)
             .withPhone(VALID_PHONE_AMY)
-            .withTags(VALID_TAG_SELLER).withHouses(HOUSE2).build();
+            .withHouses(HOUSE2)
+            .build();
 
     public static final Seller KHOONSUN_SELLER = new SellerBuilder().withName(VALID_NAME_KHOONSUN)
             .withEmail(VALID_EMAIL_KHOONSUN)
             .withPhone(VALID_PHONE_KHOONSUN)
-            .withTags(VALID_TAG_SELLER).withHouses(HOUSE1).build();
+            .withHouses(HOUSE1)
+            .build();
     public static final Seller BOB_SELLER = new SellerBuilder().withName(VALID_NAME_BOB)
             .withEmail(VALID_EMAIL_BOB)
             .withPhone(VALID_PHONE_BOB)
-            .withTags(VALID_TAG_SELLER).withHouses(HOUSE3).build();
+            .withHouses(HOUSE3)
+            .build();
 
     // Manually added - Buyer's details found in {@code CommandTestUtil}
     public static final Buyer ALI_BUYER = new BuyerBuilder().withName("Ali York")
             .withPhone("82937163").withEmail("ali@gmail.com").withBudget("400000")
-            .withHousingType("Hdb").withTags("Buyer").build();
+            .withHousingType("Hdb")
+            .build();
     public static final Buyer BEN_BUYER = new BuyerBuilder().withName(VALID_NAME_BEN).withPhone(VALID_PHONE_BEN)
             .withEmail(VALID_EMAIL_BEN).withBudget(VALID_BUDGET_BEN).withHousingType(VALID_HOUSING_TYPE_BEN)
-            .withTags("Buyer")
             .build();
 
     public static final Buyer AMY_BUYER = new BuyerBuilder().withName(VALID_NAME_AMY).withPhone(VALID_PHONE_AMY)
             .withEmail(VALID_EMAIL_AMY).withBudget(VALID_BUDGET_AMY).withHousingType(VALID_HOUSING_TYPE_AMY)
-            .withTags("Buyer")
             .build();
 
     public static final Buyer BOB_BUYER = new BuyerBuilder().withName(VALID_NAME_BOB).withPhone(VALID_PHONE_BOB)
             .withEmail(VALID_EMAIL_BOB).withBudget(VALID_BUDGET_BOB).withHousingType(VALID_HOUSING_TYPE_BOB)
-            .withTags("Buyer")
             .build();
     public static final Buyer ZACK_BUYER = new BuyerBuilder().withName("Zack York")
             .withPhone("82937163").withEmail("zack@gmail.com").withBudget("400000")
-            .withHousingType("Hdb").withTags("Buyer").build();
+            .withHousingType("Hdb")
+            .build();
     public static final Buyer ZANE_BUYER = new BuyerBuilder().withName("Zane York")
             .withPhone("82937163").withEmail("zack@gmail.com").withBudget("500000")
-            .withHousingType("Hdb").withTags("Buyer").build();
+            .withHousingType("Hdb")
+            .build();
     public static final Buyer ZURI_BUYER = new BuyerBuilder().withName("Zuri")
             .withPhone("63936234").withEmail("Zuri@gmail.com").withBudget("600000")
-            .withHousingType("Hdb").withTags("Buyer").build();
+            .withHousingType("Hdb")
+            .build();
     public static final Buyer ZYRA_BUYER = new BuyerBuilder().withName("Zyra Moore")
             .withPhone("82936234").withEmail("zyra@gmail.com").withBudget("700000")
-            .withHousingType("Hdb").withTags("Buyer").build();
+            .withHousingType("Hdb")
+            .build();
 
     // Manually added - Person's details found in {@code CommandTestUtil}
     public static final Person ALICE = new PersonBuilder().withName("Alice Pauline")
             .withEmail("alice@example.com")
             .withPhone("94351253").withHousingType("Hdb")
-            .withTags("Buyer").build();
+            .build();
     public static final Person BOB = new PersonBuilder().withName(VALID_NAME_BOB).withPhone(VALID_PHONE_BOB)
             .withEmail(VALID_EMAIL_BOB).withHousingType(VALID_HOUSING_TYPE_BOB)
-            .withTags(VALID_TAG_BUYER)
             .build();
 
     public static final String KEYWORD_MATCHING_MEIER = "Meier"; // A keyword that matches MEIER


### PR DESCRIPTION
Add tags to each person according to their type. 

- Addition of tags is no longer available during add and edit commands.
- Tags would now have a fixed value of either "Seller" or "Buyer", depending on the class type.
- Card pane of each person in the display would now have different colour, depending on their class type.