### PR TITLE
Add sorting function to internal list

### DIFF
--- a/src/main/java/seedu/address/model/person/Name.java
+++ b/src/main/java/seedu/address/model/person/Name.java
@@ -7,7 +7,7 @@ import static seedu.address.commons.util.AppUtil.checkArgument;
  * Represents a Person's name in the address book.
  * Guarantees: immutable; is valid as declared in {@link #isValidName(String)}
  */
-public class Name {
+public class Name implements Comparable<Name> {
 
     public static final String MESSAGE_CONSTRAINTS =
             "Names should only contain alphanumeric characters and spaces, and it should not be blank";
@@ -62,4 +62,8 @@ public class Name {
         return fullName.hashCode();
     }
 
+    @Override
+    public int compareTo(Name other) {
+        return this.fullName.toLowerCase().compareTo(other.fullName.toLowerCase());
+    }
 }

--- a/src/main/java/seedu/address/model/person/UniquePersonList.java
+++ b/src/main/java/seedu/address/model/person/UniquePersonList.java
@@ -3,6 +3,7 @@ package seedu.address.model.person;
 import static java.util.Objects.requireNonNull;
 import static seedu.address.commons.util.CollectionUtil.requireAllNonNull;
 
+import java.util.Comparator;
 import java.util.Iterator;
 import java.util.List;
 
@@ -76,6 +77,7 @@ public class UniquePersonList implements Iterable<Person> {
             throw new DuplicatePersonException();
         }
         internalList.add(toAdd);
+        sortInternalList();
     }
 
     /**
@@ -113,6 +115,7 @@ public class UniquePersonList implements Iterable<Person> {
         }
 
         internalList.set(index, editedPerson);
+        sortInternalList();
     }
 
     /**
@@ -141,6 +144,7 @@ public class UniquePersonList implements Iterable<Person> {
     public void setPersons(UniquePersonList replacement) {
         requireNonNull(replacement);
         internalList.setAll(replacement.internalList);
+        sortInternalList();
     }
 
     /**
@@ -154,6 +158,7 @@ public class UniquePersonList implements Iterable<Person> {
         }
 
         internalList.setAll(persons);
+        sortInternalList();
     }
 
     /**
@@ -205,5 +210,9 @@ public class UniquePersonList implements Iterable<Person> {
             }
         }
         return true;
+    }
+
+    private void sortInternalList() {
+        internalList.sort(Comparator.comparing(Person::getName));
     }
 }


### PR DESCRIPTION
Currently, the app does not sort the names on the display when adding new sellers/buyers or even when editing their names. The new contacts added are just appended at the end.

By sorting the list when add or edit command is executed, we can ensure that there's no inconsistency in the order of the contacts listed.