### PR TITLE
Fix price and budget issue when using too many decimal place by limit it to 2d.p.

### DIFF
--- a/src/main/java/seedu/address/model/house/Price.java
+++ b/src/main/java/seedu/address/model/house/Price.java
@@ -13,7 +13,6 @@ import java.math.RoundingMode;
 public class Price implements Comparable<Price> {
     public static final String MESSAGE_CONSTRAINTS = "Price should be a positive number.";
     public static final String VALIDATION_REGEX = "\\d+(\\.\\d{1,2})?"; // Allow up to 2 decimal places
-    public static final BigDecimal MAX_PRICE = new BigDecimal("1000000000000");
     public final BigDecimal value;
 
     /**
@@ -35,7 +34,7 @@ public class Price implements Comparable<Price> {
             return false; // Not a valid number format
         }
         BigDecimal priceValue = new BigDecimal(test);
-        return priceValue.compareTo(BigDecimal.ZERO) > 0 && priceValue.compareTo(MAX_PRICE) <= 0;
+        return priceValue.compareTo(BigDecimal.ZERO) > 0;
     }
 
     @Override

--- a/src/main/java/seedu/address/model/house/Price.java
+++ b/src/main/java/seedu/address/model/house/Price.java
@@ -3,14 +3,18 @@ package seedu.address.model.house;
 import static java.util.Objects.requireNonNull;
 import static seedu.address.commons.util.AppUtil.checkArgument;
 
+import java.math.BigDecimal;
+import java.math.RoundingMode;
+
 /**
  * Represents a House's Price amount.
  * Guarantees: immutable; is valid as declared in {@link #isValidPrice(String)}
  */
 public class Price implements Comparable<Price> {
     public static final String MESSAGE_CONSTRAINTS = "Price should be a positive number.";
-    public static final String VALIDATION_REGEX = "\\d+(\\.\\d+)?";
-    public final String value;
+    public static final String VALIDATION_REGEX = "\\d+(\\.\\d{1,2})?"; // Allow up to 2 decimal places
+    public static final BigDecimal MAX_PRICE = new BigDecimal("1000000000000");
+    public final BigDecimal value;
 
     /**
      * Constructs a {@code Price}.
@@ -20,19 +24,23 @@ public class Price implements Comparable<Price> {
     public Price(String price) {
         requireNonNull(price);
         checkArgument(isValidPrice(price), MESSAGE_CONSTRAINTS);
-        value = price;
+        this.value = new BigDecimal(price).setScale(2, RoundingMode.HALF_UP); // Round to 2 decimal places
     }
 
     /**
      * Returns true if a given String is a valid price amount.
      */
     public static boolean isValidPrice(String test) {
-        return test.matches(VALIDATION_REGEX) && Double.parseDouble(test) >= 0;
+        if (!test.matches(VALIDATION_REGEX)) {
+            return false; // Not a valid number format
+        }
+        BigDecimal priceValue = new BigDecimal(test);
+        return priceValue.compareTo(BigDecimal.ZERO) > 0 && priceValue.compareTo(MAX_PRICE) <= 0;
     }
 
     @Override
     public String toString() {
-        return value;
+        return value.toString();
     }
 
     @Override
@@ -57,8 +65,6 @@ public class Price implements Comparable<Price> {
 
     @Override
     public int compareTo(Price other) {
-        double thisValue = Double.parseDouble(this.value);
-        double otherValue = Double.parseDouble(other.value);
-        return Double.compare(thisValue, otherValue);
+        return value.compareTo(other.value);
     }
 }

--- a/src/main/java/seedu/address/model/person/Budget.java
+++ b/src/main/java/seedu/address/model/person/Budget.java
@@ -16,7 +16,6 @@ public class Budget {
 
     public static final String MESSAGE_CONSTRAINTS = "Budget should be positive number.";
     public static final String VALIDATION_REGEX = "\\d+(\\.\\d{1,2})?"; // Allow up to 2 decimal places
-    public static final BigDecimal MAX_BUDGET = new BigDecimal("1000000000000");
     public final BigDecimal value;
 
     /**
@@ -38,7 +37,7 @@ public class Budget {
             return false; // Not a valid number format
         }
         BigDecimal budgetValue = new BigDecimal(test);
-        return budgetValue.compareTo(BigDecimal.ZERO) > 0 && budgetValue.compareTo(MAX_BUDGET) <= 0;
+        return budgetValue.compareTo(BigDecimal.ZERO) > 0;
     }
 
     /**

--- a/src/main/java/seedu/address/model/person/Budget.java
+++ b/src/main/java/seedu/address/model/person/Budget.java
@@ -3,6 +3,9 @@ package seedu.address.model.person;
 import static java.util.Objects.requireNonNull;
 import static seedu.address.commons.util.AppUtil.checkArgument;
 
+import java.math.BigDecimal;
+import java.math.RoundingMode;
+
 import seedu.address.model.house.Price;
 
 /**
@@ -11,9 +14,10 @@ import seedu.address.model.house.Price;
  */
 public class Budget {
 
-    public static final String MESSAGE_CONSTRAINTS = "Budget should be a positive number.";
-    public static final String VALIDATION_REGEX = "\\d+(\\.\\d+)?";
-    public final String value;
+    public static final String MESSAGE_CONSTRAINTS = "Budget should be positive number.";
+    public static final String VALIDATION_REGEX = "\\d+(\\.\\d{1,2})?"; // Allow up to 2 decimal places
+    public static final BigDecimal MAX_BUDGET = new BigDecimal("1000000000000");
+    public final BigDecimal value;
 
     /**
      * Constructs a {@code Budget}.
@@ -23,14 +27,18 @@ public class Budget {
     public Budget(String budget) {
         requireNonNull(budget);
         checkArgument(isValidBudget(budget), MESSAGE_CONSTRAINTS);
-        value = budget;
+        this.value = new BigDecimal(budget).setScale(2, RoundingMode.HALF_UP); // Round to 2 decimal places
     }
 
     /**
      * Returns true if a given string is a valid budget amount.
      */
     public static boolean isValidBudget(String test) {
-        return test.matches(VALIDATION_REGEX) && Double.parseDouble(test) >= 0;
+        if (!test.matches(VALIDATION_REGEX)) {
+            return false; // Not a valid number format
+        }
+        BigDecimal budgetValue = new BigDecimal(test);
+        return budgetValue.compareTo(BigDecimal.ZERO) > 0 && budgetValue.compareTo(MAX_BUDGET) <= 0;
     }
 
     /**
@@ -39,12 +47,12 @@ public class Budget {
      * @return The Price equivalent of this budget.
      */
     public Price toPrice() {
-        return new Price(value);
+        return new Price(value.toString());
     }
 
     @Override
     public String toString() {
-        return value;
+        return value.toString();
     }
 
     @Override

--- a/src/main/java/seedu/address/storage/JsonAdaptedBuyer.java
+++ b/src/main/java/seedu/address/storage/JsonAdaptedBuyer.java
@@ -39,7 +39,7 @@ public class JsonAdaptedBuyer extends JsonAdaptedPerson {
      */
     public JsonAdaptedBuyer(Buyer source) {
         super(source);
-        budget = source.getBudget().value;
+        budget = source.getBudget().toString();
         preferredHousingType = source.getPreferredHousingType().value;
     }
 

--- a/src/main/java/seedu/address/storage/JsonAdaptedHouse.java
+++ b/src/main/java/seedu/address/storage/JsonAdaptedHouse.java
@@ -61,7 +61,7 @@ public class JsonAdaptedHouse {
         this.postalCode = source.getPostalCode().value;
         this.street = source.getStreet().value;
         this.unitNumber = source.getUnitNumber().value;
-        this.price = source.getPrice().value;
+        this.price = source.getPrice().toString();
     }
 
     private void extractHouseDetails(House source) {

--- a/src/main/java/seedu/address/ui/HouseCard.java
+++ b/src/main/java/seedu/address/ui/HouseCard.java
@@ -50,7 +50,7 @@ public class HouseCard extends UiPart<Region> {
         this.house = house;
         houseType.setText("House Type: " + house.getHousingType().value);
         postalCode.setText("Postal Code: " + house.getPostalCode().value);
-        price.setText("Price: " + house.getPrice().value);
+        price.setText("Price: $" + house.getPrice().value);
 
         if (house instanceof Hdb) {
             Hdb hdb = (Hdb) house;

--- a/src/test/java/seedu/address/testutil/PersonUtil.java
+++ b/src/test/java/seedu/address/testutil/PersonUtil.java
@@ -68,7 +68,7 @@ public class PersonUtil {
         sb.append(PREFIX_PHONE + buyer.getPhone().value + " ");
         sb.append(PREFIX_EMAIL + buyer.getEmail().value + " ");
         sb.append(PREFIX_HOUSING_TYPE + buyer.getPreferredHousingType().value + " ");
-        sb.append(PREFIX_BUDGET + buyer.getBudget().value + " ");
+        sb.append(PREFIX_BUDGET + buyer.getBudget().toString() + " ");
         return sb.toString();
     }
 


### PR DESCRIPTION
Fix #178 

The price and budget inputs were not consistently formatted to use 2 decimal places thus causing matching mismatch

Adjust the code to ensure that prices and budgets are consistently formatted with 2 decimal places.

This change improves consistency and prevents potential errors or inconsistencies in price and budget inputs.