### PR TITLE
Fix index bug issue

### DIFF
--- a/src/main/java/seedu/address/commons/util/StringUtil.java
+++ b/src/main/java/seedu/address/commons/util/StringUtil.java
@@ -65,4 +65,17 @@ public class StringUtil {
             return false;
         }
     }
+
+    /**
+     * Returns true if {@code s} represents a non-zero unsigned integer and an overflow.
+     * e.g. 2147483648, 2147483649, ... <br>
+     * Returns false for any other non-null string input.
+     */
+    public static boolean isIntegerOverflow(String s) {
+        return !isNonZeroUnsignedInteger(s) && isInteger(s);
+    }
+
+    private static boolean isInteger(String s) {
+        return s.matches("[1-9]\\d*");
+    }
 }

--- a/src/main/java/seedu/address/logic/parser/DeleteCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/DeleteCommandParser.java
@@ -23,6 +23,8 @@ public class DeleteCommandParser implements Parser<DeleteCommand> {
         } catch (ParseException pe) {
             throw new ParseException(
                     String.format(MESSAGE_INVALID_COMMAND_FORMAT, DeleteCommand.MESSAGE_USAGE), pe);
+        } catch (NumberFormatException nfe) {
+            throw new ParseException(nfe.getMessage(), nfe);
         }
     }
 

--- a/src/main/java/seedu/address/logic/parser/EditBuyerCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/EditBuyerCommandParser.java
@@ -41,6 +41,8 @@ public class EditBuyerCommandParser implements Parser<EditBuyerCommand> {
 
         } catch (ParseException pe) {
             throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, EditBuyerCommand.MESSAGE_USAGE), pe);
+        } catch (NumberFormatException nfe) {
+            throw new ParseException(nfe.getMessage(), nfe);
         }
 
         argMultimap.verifyNoDuplicatePrefixesFor(PREFIX_NAME, PREFIX_PHONE, PREFIX_EMAIL, PREFIX_HOUSING_TYPE,

--- a/src/main/java/seedu/address/logic/parser/EditSellerCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/EditSellerCommandParser.java
@@ -41,6 +41,8 @@ public class EditSellerCommandParser implements Parser<EditSellerCommand> {
         } catch (ParseException pe) {
             throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT,
                     EditSellerCommand.MESSAGE_USAGE), pe);
+        } catch (NumberFormatException nfe) {
+            throw new ParseException(nfe.getMessage(), nfe);
         }
 
         argMultimap.verifyNoDuplicatePrefixesFor(PREFIX_NAME, PREFIX_PHONE, PREFIX_EMAIL);

--- a/src/main/java/seedu/address/logic/parser/ParserUtil.java
+++ b/src/main/java/seedu/address/logic/parser/ParserUtil.java
@@ -8,6 +8,7 @@ import java.util.Set;
 
 import seedu.address.commons.core.index.Index;
 import seedu.address.commons.util.StringUtil;
+import seedu.address.logic.Messages;
 import seedu.address.logic.parser.exceptions.ParseException;
 import seedu.address.model.house.Block;
 import seedu.address.model.house.House;
@@ -38,6 +39,11 @@ public class ParserUtil {
      */
     public static Index parseIndex(String oneBasedIndex) throws ParseException {
         String trimmedIndex = oneBasedIndex.trim();
+
+        if (StringUtil.isIntegerOverflow(trimmedIndex)) {
+            throw new NumberFormatException(Messages.MESSAGE_INVALID_PERSON_DISPLAYED_INDEX);
+        }
+
         if (!StringUtil.isNonZeroUnsignedInteger(trimmedIndex)) {
             throw new ParseException(MESSAGE_INVALID_INDEX);
         }

--- a/src/main/java/seedu/address/logic/parser/ViewCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/ViewCommandParser.java
@@ -25,6 +25,8 @@ public class ViewCommandParser implements Parser<ViewCommand> {
         } catch (ParseException pe) {
             throw new ParseException(
                     String.format(MESSAGE_INVALID_COMMAND_FORMAT, ViewCommand.MESSAGE_USAGE), pe);
+        } catch (NumberFormatException nfe) {
+            throw new ParseException(nfe.getMessage(), nfe);
         }
     }
 }

--- a/src/test/java/seedu/address/commons/util/StringUtilTest.java
+++ b/src/test/java/seedu/address/commons/util/StringUtilTest.java
@@ -140,4 +140,27 @@ public class StringUtilTest {
         assertThrows(NullPointerException.class, () -> StringUtil.getDetails(null));
     }
 
+    @Test
+    public void isIntegerOverflow() {
+        // EP: integer overflow
+        assertTrue(StringUtil.isIntegerOverflow("2147483648")); // Boundary value
+        assertTrue(StringUtil.isIntegerOverflow("2147483648123"));
+
+
+        // EP: not a number
+        assertFalse(StringUtil.isIntegerOverflow("a"));
+        assertFalse(StringUtil.isIntegerOverflow("asd"));
+        assertFalse(StringUtil.isIntegerOverflow("")); // Boundary value
+        assertFalse(StringUtil.isIntegerOverflow("  "));
+
+        // EP: number + letter
+        assertFalse(StringUtil.isIntegerOverflow("1a"));
+        assertFalse(StringUtil.isIntegerOverflow("2147483648a"));
+        assertFalse(StringUtil.isIntegerOverflow("-1a"));
+        assertFalse(StringUtil.isIntegerOverflow("-0a"));
+
+        // EP: negative
+        assertFalse(StringUtil.isIntegerOverflow("-2147483648"));
+        assertFalse(StringUtil.isIntegerOverflow("-1"));
+    }
 }


### PR DESCRIPTION
Fixes #163 

In this bug fix, a validation for integer overflow is added.
When a positive integer overflow is detected, it would no longer show "INDEX (must be a positive integer)" 
but instead, warn the user that "The person index provided is invalid".

Commands Affected by this change:
- delete
- editBuyer
- editSeller
- view