### PR TITLE
Fix incorrect UI display in MatchBuyerCommand

### DIFF
--- a/src/main/java/seedu/address/logic/commands/MatchBuyerCommand.java
+++ b/src/main/java/seedu/address/logic/commands/MatchBuyerCommand.java
@@ -54,8 +54,8 @@ public class MatchBuyerCommand extends Command {
         Person person = model.getFilteredPersonList().get(0);
 
         if (!(person instanceof Buyer)) {
-            model.setState(State.MATCH_RESULTS);
-            model.showMatchResults(model.getFilteredSellerList());
+            model.setState(State.PERSON_LIST);
+            model.updateFilteredPersonList(Model.PREDICATE_SHOW_ALL_PERSONS);
             return new CommandResult(Messages.MESSAGE_NOT_A_BUYER);
         }
 


### PR DESCRIPTION
Previously, when the specified person was a seller, the MatchBuyerCommand would incorrectly display the seller's details upon first execution. However, when MatchBuyerCommand was first executed with a buyer specified, then a seller, it showed the correct result by displaying back the list containing all persons.

To address this issue, I added two lines of code:

`model.setState(State.PERSON_LIST);`
`model.updateFilteredPersonList(Model.PREDICATE_SHOW_ALL_PERSONS);`

These changes ensure correct display behaviour throughout.